### PR TITLE
Add a derivation for antlr4-python3-runtime

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -38,6 +38,8 @@ self: super:
     
     {
 
+      antlr4-python3-runtime = python-super.callPackage ./pkgs/development/python-modules/antlr4-python3-runtime {};
+
       applicationinsights = python-super.callPackage ./pkgs/development/python-modules/applicationinsights {};
 
       azure-batch = python-super.callPackage ./pkgs/development/python-modules/azure-batch { };

--- a/pkgs/development/python-modules/antlr4-python3-runtime/default.nix
+++ b/pkgs/development/python-modules/antlr4-python3-runtime/default.nix
@@ -1,0 +1,20 @@
+{ stdenv, buildPythonPackage, fetchPypi }:
+
+buildPythonPackage rec {
+  pname = "antlr4-python3-runtime";
+  version = "4.7.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1b26b72c4492cef310542da10bf6b2ab4aa1775618fc6003f75b55ae9eaa3fd3";
+  };
+
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "This is the Python 3 runtime for ANTLR";
+    homepage = http://www.antlr.org;
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ stesie ];
+  };
+}


### PR DESCRIPTION
`antlr4-python3-runtime` doesn't seem to be in nixpkgs, so this adds it to the overlay

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stesie/azure-cli-nix/1)
<!-- Reviewable:end -->
