### PR TITLE
(semi-) Automatic Update

### DIFF
--- a/auto-update
+++ b/auto-update
@@ -118,7 +118,7 @@ getDeps() {
         -e 's/enum34//' \
         -e 's/pyreadline//' -e 's/unittest2//' \
         -e 's/typing//' -e 's/importlib//'     \
-        -e 's/;//' -e 's/wheel//' \
+        -e 's/;//' \
     | sort -u
 }
 

--- a/auto-update
+++ b/auto-update
@@ -94,7 +94,7 @@ updateDependencies() {
 
     # ... and replace these
     for d in $deps; do
-      if [ "$d" != "futures" -a "$d" != "pathlib2" ]; then
+      if [ "$d" != "futures" ] && [ "$d" != "pathlib2" ]; then
         echo "    $d"
       fi
     done
@@ -178,7 +178,7 @@ createPackage() {
 }
 
 run "ls --color=never -1d *.dist-info" \
-    | tr -d "\r" \
+    | tr -d "\\r" \
     | grep -e ^applicationinsights- -e ^azure -e ^humanfriendly -e ^knack -e ^msrest \
     | while read -r name; do
     handleModule "$name"

--- a/auto-update
+++ b/auto-update
@@ -117,9 +117,9 @@ getDeps() {
         -e 's/requests-oauthlib/requests_oauthlib/' \
         -e 's/enum34//' \
         -e 's/pyreadline//' -e 's/unittest2//' \
-        -e 's/typing//' \
+        -e 's/typing//' -e 's/importlib//'     \
         -e 's/;//' -e 's/wheel//' \
-    | sort
+    | sort -u
 }
 
 createPackage() {
@@ -176,9 +176,6 @@ createPackage() {
   ) > "pkgs/development/python-modules/$dashname/default.nix"
 
 }
-
-handleModule "azure_mgmt_nspkg-3.0.2.dist-info"
-exit 0
 
 run "ls --color=never -1d *.dist-info" \
     | tr -d "\r" \

--- a/auto-update
+++ b/auto-update
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+
+set -e
+set -o pipefail
+
+run() {
+  docker run --rm microsoft/azure-cli sh -c "cd /usr/local/lib/python3.6/site-packages && $*"
+}
+
+handleModule() {
+  dirname="$1"
+  name="${dirname%.dist-info}"
+  pname="${name%-*}"
+  version="${name#*-}"
+  dashname="${pname//_/-}"
+
+  echo ""
+  echo "----------------------------------------------"
+  echo ""
+  echo "Processing Module $pname at $version"
+
+  if [ -d "pkgs/development/python-modules/$dashname" ]; then
+    currentVersion="$(getCurrentVersion "$dashname")"
+    echo "Module already exists, current version is $currentVersion ..."
+
+    if [ "$currentVersion" = "$version" ]; then
+      echo "Nothing to do."
+    else
+      echo "Updating ..."
+      updateVersion "$dashname" "$version"
+      updateHash "$pname" "$version"
+    fi
+
+    updateDependencies "$pname" "$version"
+  else
+    echo "Module is MISSING ..."
+    createPackage "$pname" "$version"
+
+  fi
+
+}
+
+getCurrentVersion() {
+  dashname="$1"
+  sed -n '/version =/ { s/";//; s/.*"//; p }' "pkgs/development/python-modules/$dashname/default.nix"
+}
+
+updateVersion() {
+  dashname="$1"
+  version="$2"
+  sed -i -e '/version =/ { s/".*"/"'"$version"'"/  }'  "pkgs/development/python-modules/$dashname/default.nix"
+}
+
+getHash() {
+  pname="$1"
+  dashname="${pname//_/-}"
+  version="$2"
+
+  python="py2.py3"
+
+  if grep -qe 'python = "py3";' "pkgs/development/python-modules/$dashname/default.nix"; then
+    python="py3";
+  fi
+
+  nix-prefetch-url "https://files.pythonhosted.org/packages/$python/${pname:0:1}/$pname/$pname-$version-$python-none-any.whl"
+}
+
+updateHash() {
+  pname="$1"
+  dashname="${pname//_/-}"
+  version="$2"
+
+  sed -i -e '/sha256 =/ { s/".*"/"'"$(getHash "$pname" "$version")"'"/  }' "pkgs/development/python-modules/$dashname/default.nix"
+}
+
+updateDependencies() {
+  pname="$1"
+  dashname="${pname//_/-}"
+  version="$2"
+
+  deps="$(getDeps "$pname" "$version")"
+
+  (
+    # copy over old "base" dependencies
+    sed -ne '1p' < "pkgs/development/python-modules/$dashname/default.nix"
+
+    # insert dependency data as per module's metadata
+    for d in $deps; do
+      echo ", $d"
+    done
+
+    # copy stuff until propagatedBuildInputs, ...
+    sed -ne '/^}:/,/propagatedBuildInputs/ { p }' < "pkgs/development/python-modules/$dashname/default.nix"
+
+    # ... and replace these
+    for d in $deps; do
+      if [ "$d" != "futures" -a "$d" != "pathlib2" ]; then
+        echo "    $d"
+      fi
+    done
+
+    # ... copy the rest of the file (@todo anchor is pretty weak)
+    sed -ne '/^  ]/,$ { p }' < "pkgs/development/python-modules/$dashname/default.nix"
+  ) > "pkgs/development/python-modules/$dashname/default.nix.new"
+
+  mv -f "pkgs/development/python-modules/$dashname/default.nix.new" "pkgs/development/python-modules/$dashname/default.nix"
+}
+
+getDeps() {
+  pname="$1"
+  version="$2"
+
+  run awk "\"/^Requires-Dist:/ { print \\\$2 }\"" "$pname-$version.dist-info/METADATA" \
+    | sed -e 's/pyOpenSSL/pyopenssl/' -e 's/urllib3\[secure\]/urllib3/' \
+        -e 's/websocket-client/websocket_client/' -e 's/PyJWT/pyjwt/'   \
+        -e 's/prompt-toolkit/prompt_toolkit/'       \
+        -e 's/requests-oauthlib/requests_oauthlib/' \
+        -e 's/enum34//' \
+        -e 's/pyreadline//' -e 's/unittest2//' \
+        -e 's/typing//' \
+        -e 's/;//' -e 's/wheel//' \
+    | sort
+}
+
+createPackage() {
+  pname="$1"
+  dashname="${pname//_/-}"
+  version="$2"
+
+  mkdir -p "pkgs/development/python-modules/$dashname"
+
+  deps="$(getDeps "$pname" "$version")"
+
+  (
+    echo "{ stdenv, buildPythonPackage, fetchPypi, python"
+
+    # insert dependency data as per module's metadata
+    for d in $deps; do
+      echo ", $d"
+    done
+
+    echo "}:"
+    echo ""
+    echo "buildPythonPackage rec {"
+    echo "  pname = \"$pname\";"
+    echo "  version = \"$version\";"
+    echo "  format = \"wheel\";"
+    echo ""
+    echo "  src = fetchPypi {"
+    echo "    inherit pname version format;"
+    echo "    sha256 = \"$(getHash "$pname" "$version")\";"
+    echo "  };"
+    echo ""
+    echo "  propagatedBuildInputs = ["
+
+    for d in $deps; do
+      echo "    $d"
+    done
+
+    echo "  ];"
+    echo ""
+    echo "  doCheck = false;"
+    echo "  "
+    echo "  meta = with stdenv.lib; {"
+
+    summary="$(run grep -e ^Summary: "$pname-$version.dist-info/METADATA" | cut -c10-)"
+    echo "    description = \"$summary\";"
+
+    url="$(run grep -e ^Home-page: "$pname-$version.dist-info/METADATA" | cut -c12-)"
+    echo "    homepage = $url;"
+
+    echo "    license = licenses.mit;"
+    echo "    maintainers = with maintainers; [ stesie ];"
+    echo "  };"
+    echo "}"
+  ) > "pkgs/development/python-modules/$dashname/default.nix"
+
+}
+
+handleModule "azure_mgmt_nspkg-3.0.2.dist-info"
+exit 0
+
+run "ls --color=never -1d *.dist-info" \
+    | tr -d "\r" \
+    | grep -e ^applicationinsights- -e ^azure -e ^humanfriendly -e ^knack -e ^msrest \
+    | while read -r name; do
+    handleModule "$name"
+done

--- a/default.nix
+++ b/default.nix
@@ -64,6 +64,8 @@ self: super:
 
       azure-cli-billing = python-super.callPackage ./pkgs/development/python-modules/azure-cli-billing { };
 
+      azure-cli-botservice = python-super.callPackage ./pkgs/development/python-modules/azure-cli-botservice { };
+
       azure-cli-cdn = python-super.callPackage ./pkgs/development/python-modules/azure-cli-cdn { };
 
       azure-cli-cloud = python-super.callPackage ./pkgs/development/python-modules/azure-cli-cloud { };
@@ -103,15 +105,21 @@ self: super:
 
       azure-cli-find = python-super.callPackage ./pkgs/development/python-modules/azure-cli-find { };
 
+      azure-cli-hdinsight = python-super.callPackage ./pkgs/development/python-modules/azure-cli-hdinsight { };
+
       azure-cli-interactive = python-super.callPackage ./pkgs/development/python-modules/azure-cli-interactive {
         jmespath = my_jmespath;
       };
 
       azure-cli-iot = python-super.callPackage ./pkgs/development/python-modules/azure-cli-iot { };
 
+      azure-cli-iotcentral = python-super.callPackage ./pkgs/development/python-modules/azure-cli-iotcentral { };
+
       azure-cli-keyvault = python-super.callPackage ./pkgs/development/python-modules/azure-cli-keyvault { };
 
       azure-cli-lab = python-super.callPackage ./pkgs/development/python-modules/azure-cli-lab { };
+
+      azure-cli-maps = python-super.callPackage ./pkgs/development/python-modules/azure-cli-maps { };
 
       azure-cli-monitor = python-super.callPackage ./pkgs/development/python-modules/azure-cli-monitor { };
 
@@ -119,11 +127,15 @@ self: super:
 
       azure-cli-nspkg = python-super.callPackage ./pkgs/development/python-modules/azure-cli-nspkg { };
 
+      azure-cli-policyinsights = python-super.callPackage ./pkgs/development/python-modules/azure-cli-policyinsights { };
+
       azure-cli-profile = python-super.callPackage ./pkgs/development/python-modules/azure-cli-profile { };
 
       azure-cli-rdbms = python-super.callPackage ./pkgs/development/python-modules/azure-cli-rdbms { };
 
       azure-cli-redis = python-super.callPackage ./pkgs/development/python-modules/azure-cli-redis { };
+
+      azure-cli-relay = python-super.callPackage ./pkgs/development/python-modules/azure-cli-relay { };
 
       azure-cli-reservations = python-super.callPackage ./pkgs/development/python-modules/azure-cli-reservations { };
 
@@ -136,6 +148,8 @@ self: super:
       azure-cli-servicebus = python-super.callPackage ./pkgs/development/python-modules/azure-cli-servicebus { };
 
       azure-cli-servicefabric = python-super.callPackage ./pkgs/development/python-modules/azure-cli-servicefabric { };
+
+      azure-cli-signalr = python-super.callPackage ./pkgs/development/python-modules/azure-cli-signalr { };
 
       azure-cli-sql = python-super.callPackage ./pkgs/development/python-modules/azure-cli-sql { };
 
@@ -166,6 +180,8 @@ self: super:
       azure-mgmt-batchai = python-super.callPackage ./pkgs/development/python-modules/azure-mgmt-batchai { };
 
       azure-mgmt-billing = python-super.callPackage ./pkgs/development/python-modules/azure-mgmt-billing { };
+
+      azure-mgmt-botservice = python-super.callPackage ./pkgs/development/python-modules/azure-mgmt-botservice { };
 
       azure-mgmt-cdn = python-super.callPackage ./pkgs/development/python-modules/azure-mgmt-cdn { };
 
@@ -199,6 +215,10 @@ self: super:
 
       azure-mgmt-eventhub = python-super.callPackage ./pkgs/development/python-modules/azure-mgmt-eventhub { };
 
+      azure-mgmt-hdinsight = python-super.callPackage ./pkgs/development/python-modules/azure-mgmt-hdinsight { };
+
+      azure-mgmt-iotcentral = python-super.callPackage ./pkgs/development/python-modules/azure-mgmt-iotcentral { };
+
       azure-mgmt-iothub = python-super.callPackage ./pkgs/development/python-modules/azure-mgmt-iothub { };
 
       azure-mgmt-iothubprovisioningservices = python-super.callPackage ./pkgs/development/python-modules/azure-mgmt-iothubprovisioningservices { };
@@ -208,6 +228,8 @@ self: super:
       azure-mgmt-loganalytics = python-super.callPackage ./pkgs/development/python-modules/azure-mgmt-loganalytics { };
 
       azure-mgmt-managementgroups = python-super.callPackage ./pkgs/development/python-modules/azure-mgmt-managementgroups { };
+
+      azure-mgmt-maps = python-super.callPackage ./pkgs/development/python-modules/azure-mgmt-maps { };
 
       azure-mgmt-marketplaceordering = python-super.callPackage ./pkgs/development/python-modules/azure-mgmt-marketplaceordering { };
 
@@ -221,6 +243,8 @@ self: super:
 
       azure-mgmt-nspkg = python-super.callPackage ./pkgs/development/python-modules/azure-mgmt-nspkg { };
 
+      azure-mgmt-policyinsights = python-super.callPackage ./pkgs/development/python-modules/azure-mgmt-policyinsights { };
+
       azure-mgmt-rdbms = python-super.callPackage ./pkgs/development/python-modules/azure-mgmt-rdbms { };
 
       azure-mgmt-recoveryservices = python-super.callPackage ./pkgs/development/python-modules/azure-mgmt-recoveryservices { };
@@ -228,6 +252,8 @@ self: super:
       azure-mgmt-recoveryservicesbackup = python-super.callPackage ./pkgs/development/python-modules/azure-mgmt-recoveryservicesbackup { };
 
       azure-mgmt-redis = python-super.callPackage ./pkgs/development/python-modules/azure-mgmt-redis { };
+
+      azure-mgmt-relay = python-super.callPackage ./pkgs/development/python-modules/azure-mgmt-relay { };
 
       azure-mgmt-reservations = python-super.callPackage ./pkgs/development/python-modules/azure-mgmt-reservations { };
 
@@ -238,6 +264,8 @@ self: super:
       azure-mgmt-servicebus = python-super.callPackage ./pkgs/development/python-modules/azure-mgmt-servicebus { };
 
       azure-mgmt-servicefabric = python-super.callPackage ./pkgs/development/python-modules/azure-mgmt-servicefabric { };
+
+      azure-mgmt-signalr = python-super.callPackage ./pkgs/development/python-modules/azure-mgmt-signalr { };
 
       azure-mgmt-sql = python-super.callPackage ./pkgs/development/python-modules/azure-mgmt-sql { };
 

--- a/pkgs/development/python-modules/applicationinsights/default.nix
+++ b/pkgs/development/python-modules/applicationinsights/default.nix
@@ -1,13 +1,18 @@
-{ stdenv, buildPythonPackage, fetchPypi }:
+{ stdenv, buildPythonPackage, fetchPypi
+}:
 
 buildPythonPackage rec {
   pname = "applicationinsights";
-  version = "0.11.6";
+  version = "0.11.7";
+  format = "wheel";
 
   src = fetchPypi {
-    inherit pname version;
-    sha256 = "0b5abcdxbakqxsha6427qjwgvgh7j8p57apw495rvzm6hcv9d302";
+    inherit pname version format;
+    sha256 = "1zhrl8bpwga4l906k83m9yrx4rh15hnmppvg4kcgs7ymz82yp8j2";
   };
+
+  propagatedBuildInputs = [
+  ];
 
   doCheck = false;
 

--- a/pkgs/development/python-modules/azure-batch/default.nix
+++ b/pkgs/development/python-modules/azure-batch/default.nix
@@ -5,13 +5,13 @@
 }:
 
 buildPythonPackage rec {
-  pname = "azure-batch";
-  version = "4.1.3";
+  pname = "azure_batch";
+  version = "5.1.0";
+  format = "wheel";
 
   src = fetchPypi {
-    inherit pname version;
-    extension = "zip";
-    sha256 = "0k1n73qpa2ns2kjsf9rjsv4b0vcdw6dggfr5c95igaxynpmwfwfd";
+    inherit pname version format;
+    sha256 = "0vm7l4kqg65byllqrrgvnpcxariis1qagc2cfxmh2yjbyy0g647w";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/azure-cli-acr/default.nix
+++ b/pkgs/development/python-modules/azure-cli-acr/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPythonPackage, fetchPypi
+{ stdenv, buildPythonPackage, fetchPypi, python
 , azure-cli-command-modules-nspkg
 , azure-cli-core
 , azure-mgmt-containerregistry
@@ -15,6 +15,12 @@ buildPythonPackage rec {
     inherit pname version format;
     sha256 = "10jdzrz6qx2vnlzjrfmn333b2a1kk79dhlbzyz0jsxv1zh4ly14i";
   };
+
+  postFixup = ''
+    rm "$out/lib/${python.libPrefix}/site-packages/azure/__init__.py"
+    rm "$out/lib/${python.libPrefix}/site-packages/azure/cli/__init__.py"
+    rm "$out/lib/${python.libPrefix}/site-packages/azure/cli/command_modules/__init__.py"
+  '';
 
   propagatedBuildInputs = [
     azure-cli-command-modules-nspkg

--- a/pkgs/development/python-modules/azure-cli-acr/default.nix
+++ b/pkgs/development/python-modules/azure-cli-acr/default.nix
@@ -8,12 +8,12 @@
 
 buildPythonPackage rec {
   pname = "azure_cli_acr";
-  version = "2.1.0";
+  version = "2.1.7";
   format = "wheel";
 
   src = fetchPypi {
     inherit pname version format;
-    sha256 = "0mprxk87pmwkqbz1jd9m4kd0njgf901ghf0zzp6qwdj542hjkd5z";
+    sha256 = "10jdzrz6qx2vnlzjrfmn333b2a1kk79dhlbzyz0jsxv1zh4ly14i";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/azure-cli-acs/default.nix
+++ b/pkgs/development/python-modules/azure-cli-acs/default.nix
@@ -14,12 +14,12 @@
 
 buildPythonPackage rec {
   pname = "azure_cli_acs";
-  version = "2.0.34";
+  version = "2.3.9";
   format = "wheel";
 
   src = fetchPypi {
     inherit pname version format;
-    sha256 = "1cbgbn3iii8bxy844kvgzrgpy8b89djj69gxmj4m7vlfvzjcawgc";
+    sha256 = "0jm8mjsdz39ryabpvxi8vpldc5gg6x3zlpacy9913z02q8c94102";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/azure-cli-acs/default.nix
+++ b/pkgs/development/python-modules/azure-cli-acs/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPythonPackage, fetchPypi
+{ stdenv, buildPythonPackage, fetchPypi, python
 , azure-cli-command-modules-nspkg
 , azure-cli-core
 , azure-graphrbac
@@ -21,6 +21,12 @@ buildPythonPackage rec {
     inherit pname version format;
     sha256 = "0jm8mjsdz39ryabpvxi8vpldc5gg6x3zlpacy9913z02q8c94102";
   };
+
+  postFixup = ''
+    rm "$out/lib/${python.libPrefix}/site-packages/azure/__init__.py"
+    rm "$out/lib/${python.libPrefix}/site-packages/azure/cli/__init__.py"
+    rm "$out/lib/${python.libPrefix}/site-packages/azure/cli/command_modules/__init__.py"
+  '';
 
   propagatedBuildInputs = [
     azure-cli-command-modules-nspkg

--- a/pkgs/development/python-modules/azure-cli-ams/default.nix
+++ b/pkgs/development/python-modules/azure-cli-ams/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPythonPackage, fetchPypi
+{ stdenv, buildPythonPackage, fetchPypi, python
 , azure-cli-command-modules-nspkg
 , azure-cli-core
 , azure-graphrbac
@@ -14,6 +14,12 @@ buildPythonPackage rec {
     inherit pname version format;
     sha256 = "0bj2n2vsz2hrhrr9i35s12363kbl3wlprydbmqgxcrv8ij22s7dk";
   };
+
+  postFixup = ''
+    rm "$out/lib/${python.libPrefix}/site-packages/azure/__init__.py"
+    rm "$out/lib/${python.libPrefix}/site-packages/azure/cli/__init__.py"
+    rm "$out/lib/${python.libPrefix}/site-packages/azure/cli/command_modules/__init__.py"
+  '';
 
   propagatedBuildInputs = [
     azure-cli-command-modules-nspkg

--- a/pkgs/development/python-modules/azure-cli-ams/default.nix
+++ b/pkgs/development/python-modules/azure-cli-ams/default.nix
@@ -7,12 +7,12 @@
 
 buildPythonPackage rec {
   pname = "azure_cli_ams";
-  version = "0.2.3";
+  version = "0.2.4";
   format = "wheel";
 
   src = fetchPypi {
     inherit pname version format;
-    sha256 = "1bds3843dpib3xhdw2nyagryhnn22hcq44pm4kgkrsgg47b3yqi7";
+    sha256 = "0bj2n2vsz2hrhrr9i35s12363kbl3wlprydbmqgxcrv8ij22s7dk";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/azure-cli-appservice/default.nix
+++ b/pkgs/development/python-modules/azure-cli-appservice/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPythonPackage, fetchPypi
+{ stdenv, buildPythonPackage, fetchPypi, python
 , azure-cli-command-modules-nspkg
 , azure-cli-core
 , azure-mgmt-containerregistry
@@ -20,6 +20,12 @@ buildPythonPackage rec {
     inherit pname version format;
     sha256 = "0m7zm0snfh8f1msi5ivv5azkm3l91ixcy84g1ldv2jfxdg9y1d9d";
   };
+
+  postFixup = ''
+    rm "$out/lib/${python.libPrefix}/site-packages/azure/__init__.py"
+    rm "$out/lib/${python.libPrefix}/site-packages/azure/cli/__init__.py"
+    rm "$out/lib/${python.libPrefix}/site-packages/azure/cli/command_modules/__init__.py"
+  '';
 
   propagatedBuildInputs = [
     azure-cli-command-modules-nspkg

--- a/pkgs/development/python-modules/azure-cli-appservice/default.nix
+++ b/pkgs/development/python-modules/azure-cli-appservice/default.nix
@@ -13,12 +13,12 @@
 
 buildPythonPackage rec {
   pname = "azure_cli_appservice";
-  version = "0.1.36";
+  version = "0.2.5";
   format = "wheel";
 
   src = fetchPypi {
     inherit pname version format;
-    sha256 = "0ghi4yi2x22gk64sx7sivpvnvqcvjjchckydla1glicr1piwzn7a";
+    sha256 = "0m7zm0snfh8f1msi5ivv5azkm3l91ixcy84g1ldv2jfxdg9y1d9d";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/azure-cli-batch/default.nix
+++ b/pkgs/development/python-modules/azure-cli-batch/default.nix
@@ -1,25 +1,25 @@
 { stdenv, buildPythonPackage, fetchPypi
 , azure-batch
-, azure-cli-core
 , azure-cli-command-modules-nspkg
+, azure-cli-core
 , azure-mgmt-batch
 , azure-mgmt-keyvault
 }:
 
 buildPythonPackage rec {
   pname = "azure_cli_batch";
-  version = "3.2.4";
+  version = "3.4.1";
   format = "wheel";
 
   src = fetchPypi {
     inherit pname version format;
-    sha256 = "04hhqcxvx5yq5iawvcf0dannz342mjrzbanh859y6n62za6khgxj";
+    sha256 = "19z76ik99vl6i20jvad8mys5jhrcy181kqw18lwnmp8945ir1lfk";
   };
 
   propagatedBuildInputs = [
     azure-batch
-    azure-cli-core
     azure-cli-command-modules-nspkg
+    azure-cli-core
     azure-mgmt-batch
     azure-mgmt-keyvault
   ];

--- a/pkgs/development/python-modules/azure-cli-batch/default.nix
+++ b/pkgs/development/python-modules/azure-cli-batch/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPythonPackage, fetchPypi
+{ stdenv, buildPythonPackage, fetchPypi, python
 , azure-batch
 , azure-cli-command-modules-nspkg
 , azure-cli-core
@@ -15,6 +15,12 @@ buildPythonPackage rec {
     inherit pname version format;
     sha256 = "19z76ik99vl6i20jvad8mys5jhrcy181kqw18lwnmp8945ir1lfk";
   };
+
+  postFixup = ''
+    rm "$out/lib/${python.libPrefix}/site-packages/azure/__init__.py"
+    rm "$out/lib/${python.libPrefix}/site-packages/azure/cli/__init__.py"
+    rm "$out/lib/${python.libPrefix}/site-packages/azure/cli/command_modules/__init__.py"
+  '';
 
   propagatedBuildInputs = [
     azure-batch

--- a/pkgs/development/python-modules/azure-cli-batchai/default.nix
+++ b/pkgs/development/python-modules/azure-cli-batchai/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPythonPackage, fetchPypi
+{ stdenv, buildPythonPackage, fetchPypi, python
 , azure-cli-command-modules-nspkg
 , azure-cli-core
 , azure-mgmt-batchai
@@ -17,6 +17,12 @@ buildPythonPackage rec {
     inherit pname version format;
     sha256 = "14aw947yvdszdancwyrh25vid5ajhn5c76ppm17fwkv9xwa7gidq";
   };
+
+  postFixup = ''
+    rm "$out/lib/${python.libPrefix}/site-packages/azure/__init__.py"
+    rm "$out/lib/${python.libPrefix}/site-packages/azure/cli/__init__.py"
+    rm "$out/lib/${python.libPrefix}/site-packages/azure/cli/command_modules/__init__.py"
+  '';
 
   propagatedBuildInputs = [
     azure-cli-command-modules-nspkg

--- a/pkgs/development/python-modules/azure-cli-batchai/default.nix
+++ b/pkgs/development/python-modules/azure-cli-batchai/default.nix
@@ -10,12 +10,12 @@
 
 buildPythonPackage rec {
   pname = "azure_cli_batchai";
-  version = "0.4.0";
+  version = "0.4.4";
   format = "wheel";
 
   src = fetchPypi {
     inherit pname version format;
-    sha256 = "1kacgxmzf23ja9nynkirwqpsdys11rb46k9bb4nhcflmmfg1wf56";
+    sha256 = "14aw947yvdszdancwyrh25vid5ajhn5c76ppm17fwkv9xwa7gidq";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/azure-cli-botservice/default.nix
+++ b/pkgs/development/python-modules/azure-cli-botservice/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, buildPythonPackage, fetchPypi, python
+, azure-cli-command-modules-nspkg
+, azure-cli-core
+, azure-mgmt-botservice
+, azure-mgmt-web
+}:
+
+buildPythonPackage rec {
+  pname = "azure_cli_botservice";
+  version = "0.1.1";
+  format = "wheel";
+
+  src = fetchPypi {
+    inherit pname version format;
+    sha256 = "0zrk1rs8cspr6rchjfpfm6i1lhaxdgf1y3l118jvbk8702bb6ify";
+  };
+
+  propagatedBuildInputs = [
+    azure-cli-command-modules-nspkg
+    azure-cli-core
+    azure-mgmt-botservice
+    azure-mgmt-web
+  ];
+
+  doCheck = false;
+  
+  meta = with stdenv.lib; {
+    description = "Microsoft Azure Command-Line Tools Bot Services Command Module";
+    homepage = https://github.com/azure/azure-cli;
+    license = licenses.mit;
+    maintainers = with maintainers; [ stesie ];
+  };
+}

--- a/pkgs/development/python-modules/azure-cli-cdn/default.nix
+++ b/pkgs/development/python-modules/azure-cli-cdn/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPythonPackage, fetchPypi
+{ stdenv, buildPythonPackage, fetchPypi, python
 , azure-cli-command-modules-nspkg
 , azure-cli-core
 , azure-mgmt-cdn
@@ -13,6 +13,12 @@ buildPythonPackage rec {
     inherit pname version format;
     sha256 = "1ld2vgcnjcskq3hqnyrjc9a3vn37rz9bxamsxlwknsnwq42pcr03";
   };
+
+  postFixup = ''
+    rm "$out/lib/${python.libPrefix}/site-packages/azure/__init__.py"
+    rm "$out/lib/${python.libPrefix}/site-packages/azure/cli/__init__.py"
+    rm "$out/lib/${python.libPrefix}/site-packages/azure/cli/command_modules/__init__.py"
+  '';
 
   propagatedBuildInputs = [
     azure-cli-command-modules-nspkg

--- a/pkgs/development/python-modules/azure-cli-cdn/default.nix
+++ b/pkgs/development/python-modules/azure-cli-cdn/default.nix
@@ -6,12 +6,12 @@
 
 buildPythonPackage rec {
   pname = "azure_cli_cdn";
-  version = "0.1.1";
+  version = "0.2.0";
   format = "wheel";
 
   src = fetchPypi {
     inherit pname version format;
-    sha256 = "1ba70j0j0xcpxbv20ig48vc91c74cvxlxw51gh5i5pcj4xkaprg4";
+    sha256 = "1ld2vgcnjcskq3hqnyrjc9a3vn37rz9bxamsxlwknsnwq42pcr03";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/azure-cli-cognitiveservices/default.nix
+++ b/pkgs/development/python-modules/azure-cli-cognitiveservices/default.nix
@@ -6,12 +6,12 @@
 
 buildPythonPackage rec {
   pname = "azure_cli_cognitiveservices";
-  version = "0.2.1";
+  version = "0.2.3";
   format = "wheel";
 
   src = fetchPypi {
     inherit pname version format;
-    sha256 = "0530lppkzxvzngi9v7p1n1v6bkfnq5nj4ngrcdij9k4qhr3drmqp";
+    sha256 = "1k171z887dny6g4ypgklwxn5lgv4qgv5n3pg57mchxgsmy74p5sn";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/azure-cli-container/default.nix
+++ b/pkgs/development/python-modules/azure-cli-container/default.nix
@@ -1,8 +1,10 @@
 { stdenv, buildPythonPackage, fetchPypi
 , azure-cli-command-modules-nspkg
 , azure-cli-core
+, azure-mgmt-authorization
 , azure-mgmt-containerinstance
 , azure-mgmt-loganalytics
+, azure-mgmt-network
 , azure-mgmt-resource
 , colorama
 , pyyaml
@@ -11,19 +13,21 @@
 
 buildPythonPackage rec {
   pname = "azure_cli_container";
-  version = "0.3.2";
+  version = "0.3.7";
   format = "wheel";
 
   src = fetchPypi {
     inherit pname version format;
-    sha256 = "0aw5pmzjwm3m34p27smr9mfvrq0kan29n9mpn12rkqqgs34im3kn";
+    sha256 = "17rwwrwy33qf20s4h905ibpxhbfzgpjgr3qqrhs17q6lzr67dnfx";
   };
 
   propagatedBuildInputs = [
     azure-cli-command-modules-nspkg
     azure-cli-core
+    azure-mgmt-authorization
     azure-mgmt-containerinstance
     azure-mgmt-loganalytics
+    azure-mgmt-network
     azure-mgmt-resource
     colorama
     pyyaml

--- a/pkgs/development/python-modules/azure-cli-container/default.nix
+++ b/pkgs/development/python-modules/azure-cli-container/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPythonPackage, fetchPypi
+{ stdenv, buildPythonPackage, fetchPypi, python
 , azure-cli-command-modules-nspkg
 , azure-cli-core
 , azure-mgmt-authorization
@@ -20,6 +20,12 @@ buildPythonPackage rec {
     inherit pname version format;
     sha256 = "17rwwrwy33qf20s4h905ibpxhbfzgpjgr3qqrhs17q6lzr67dnfx";
   };
+
+  postFixup = ''
+    rm "$out/lib/${python.libPrefix}/site-packages/azure/__init__.py"
+    rm "$out/lib/${python.libPrefix}/site-packages/azure/cli/__init__.py"
+    rm "$out/lib/${python.libPrefix}/site-packages/azure/cli/command_modules/__init__.py"
+  '';
 
   propagatedBuildInputs = [
     azure-cli-command-modules-nspkg

--- a/pkgs/development/python-modules/azure-cli-core/default.nix
+++ b/pkgs/development/python-modules/azure-cli-core/default.nix
@@ -1,7 +1,10 @@
 { stdenv, buildPythonPackage, fetchPypi, python
 , adal
+, antlr4-python3-runtime
 , argcomplete
+, azure-cli-nspkg
 , azure-cli-telemetry
+, azure-mgmt-resource
 , colorama
 , humanfriendly
 , jmespath
@@ -17,37 +20,46 @@
 , requests
 , six
 , tabulate
-, azure-mgmt-resource
-, azure-cli-nspkg
-, antlr4-python3-runtime
 }:
 
 buildPythonPackage rec {
-  pname = "azure-cli-core";
-  version = "2.0.43";
+  pname = "azure_cli_core";
+  version = "2.0.49";
+  format = "wheel";
 
   src = fetchPypi {
-    inherit pname version;
-    sha256 = "08q8gxpgs15rvwxf6dmryg9ax9ki7sy22jaqfi7g9y1rvfbnqmlq";
+    inherit pname version format;
+    sha256 = "1jrbvhqilwkiaqkcp3r2g358mrsjq4hiym522ijcx4dskrvxgdg1";
   };
-
-  # Hackily force build w/ wheel 0.31
-  postPatch = ''
-    sed -e '/azure-namespace-package/d' -i  setup.cfg
-    sed -e 's/wheel==0.30.0/wheel/' -i setup.py azure_cli_core.egg-info/requires.txt
-  '';
 
   postFixup = ''
     rm "$out/lib/${python.libPrefix}/site-packages/azure/__init__.py"
     rm "$out/lib/${python.libPrefix}/site-packages/azure/cli/__init__.py"
   '';
 
-  propagatedBuildInputs = [ adal argcomplete azure-cli-telemetry colorama
-                            humanfriendly jmespath knack msrest msrestazure
-                            paramiko pip pygments pyjwt pyopenssl pyyaml
-                            requests six tabulate azure-mgmt-resource
-                            azure-cli-nspkg antlr4-python3-runtime
-                          ];
+  propagatedBuildInputs = [
+    adal
+    antlr4-python3-runtime
+    argcomplete
+    azure-cli-nspkg
+    azure-cli-telemetry
+    azure-mgmt-resource
+    colorama
+    humanfriendly
+    jmespath
+    knack
+    msrest
+    msrestazure
+    paramiko
+    pip
+    pygments
+    pyjwt
+    pyopenssl
+    pyyaml
+    requests
+    six
+    tabulate
+  ];
 
   doCheck = false;
 

--- a/pkgs/development/python-modules/azure-cli-core/default.nix
+++ b/pkgs/development/python-modules/azure-cli-core/default.nix
@@ -20,6 +20,7 @@
 , requests
 , six
 , tabulate
+, wheel
 }:
 
 buildPythonPackage rec {
@@ -64,6 +65,7 @@ buildPythonPackage rec {
     requests
     six
     tabulate
+    wheel
   ];
 
   doCheck = false;

--- a/pkgs/development/python-modules/azure-cli-core/default.nix
+++ b/pkgs/development/python-modules/azure-cli-core/default.nix
@@ -23,14 +23,19 @@
 }:
 
 buildPythonPackage rec {
-  pname = "azure_cli_core";
+  pname = "azure-cli-core";
   version = "2.0.49";
-  format = "wheel";
 
   src = fetchPypi {
-    inherit pname version format;
-    sha256 = "1jrbvhqilwkiaqkcp3r2g358mrsjq4hiym522ijcx4dskrvxgdg1";
+    inherit pname version;
+    sha256 = "1vb3rmvlfaw8wlgi4f3ay2i0nr3j86x0ydxy04rf3ylp8kw7r5km";
   };
+
+  # Hackily force build w/ wheel 0.31
+  postPatch = ''
+    sed -e '/azure-namespace-package/d' -i  setup.cfg
+    sed -e 's/wheel==0.30.0/wheel/' -i setup.py azure_cli_core.egg-info/requires.txt
+  '';
 
   postFixup = ''
     rm "$out/lib/${python.libPrefix}/site-packages/azure/__init__.py"

--- a/pkgs/development/python-modules/azure-cli-cosmosdb/default.nix
+++ b/pkgs/development/python-modules/azure-cli-cosmosdb/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPythonPackage, fetchPypi
+{ stdenv, buildPythonPackage, fetchPypi, python
 , azure-cli-command-modules-nspkg
 , azure-cli-core
 , azure-mgmt-cosmosdb
@@ -14,6 +14,12 @@ buildPythonPackage rec {
     inherit pname version format;
     sha256 = "1zp46ylzxz9fghjsmfpp354gapxa99yfvna2f19x69hfd4wwgb3p";
   };
+
+  postFixup = ''
+    rm "$out/lib/${python.libPrefix}/site-packages/azure/__init__.py"
+    rm "$out/lib/${python.libPrefix}/site-packages/azure/cli/__init__.py"
+    rm "$out/lib/${python.libPrefix}/site-packages/azure/cli/command_modules/__init__.py"
+  '';
 
   propagatedBuildInputs = [
     azure-cli-command-modules-nspkg

--- a/pkgs/development/python-modules/azure-cli-cosmosdb/default.nix
+++ b/pkgs/development/python-modules/azure-cli-cosmosdb/default.nix
@@ -7,12 +7,12 @@
 
 buildPythonPackage rec {
   pname = "azure_cli_cosmosdb";
-  version = "0.2.1";
+  version = "0.2.2";
   format = "wheel";
 
   src = fetchPypi {
     inherit pname version format;
-    sha256 = "0ki6sc22fy0gy23j8nms2sd0r09gv1m4826mby8xm8wljygzjxpx";
+    sha256 = "1zp46ylzxz9fghjsmfpp354gapxa99yfvna2f19x69hfd4wwgb3p";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/azure-cli-dla/default.nix
+++ b/pkgs/development/python-modules/azure-cli-dla/default.nix
@@ -7,12 +7,12 @@
 
 buildPythonPackage rec {
   pname = "azure_cli_dla";
-  version = "0.2.2";
+  version = "0.2.3";
   format = "wheel";
 
   src = fetchPypi {
     inherit pname version format;
-    sha256 = "06n4kjmw3m6wp5x5nb180v7qpvnvspk3cn68cx8rq66rpasaivkk";
+    sha256 = "169jrf16b2kz10ly1zhn9asnhid39mm069l9df3vby4m5mqadqhn";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/azure-cli-dls/default.nix
+++ b/pkgs/development/python-modules/azure-cli-dls/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPythonPackage, fetchPypi
+{ stdenv, buildPythonPackage, fetchPypi, python
 , azure-cli-command-modules-nspkg
 , azure-cli-core
 , azure-datalake-store
@@ -14,6 +14,12 @@ buildPythonPackage rec {
     inherit pname version format;
     sha256 = "0qfcghcnvs3mnqf2iphmy49g6ljrs7b024l8wlvlm74sl4flh14a";
   };
+
+  postFixup = ''
+    rm "$out/lib/${python.libPrefix}/site-packages/azure/__init__.py"
+    rm "$out/lib/${python.libPrefix}/site-packages/azure/cli/__init__.py"
+    rm "$out/lib/${python.libPrefix}/site-packages/azure/cli/command_modules/__init__.py"
+  '';
 
   propagatedBuildInputs = [
     azure-cli-command-modules-nspkg

--- a/pkgs/development/python-modules/azure-cli-dls/default.nix
+++ b/pkgs/development/python-modules/azure-cli-dls/default.nix
@@ -7,12 +7,12 @@
 
 buildPythonPackage rec {
   pname = "azure_cli_dls";
-  version = "0.1.1";
+  version = "0.1.4";
   format = "wheel";
 
   src = fetchPypi {
     inherit pname version format;
-    sha256 = "03mzb9k0yn6pgiarw5clmcw7h4dajlwml6mnlpnwzzwlfqpjlb4p";
+    sha256 = "0qfcghcnvs3mnqf2iphmy49g6ljrs7b024l8wlvlm74sl4flh14a";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/azure-cli-dms/default.nix
+++ b/pkgs/development/python-modules/azure-cli-dms/default.nix
@@ -7,12 +7,12 @@
 
 buildPythonPackage rec {
   pname = "azure_cli_dms";
-  version = "0.1.0";
+  version = "0.1.1";
   format = "wheel";
 
   src = fetchPypi {
     inherit pname version format;
-    sha256 = "043m110l4kw522d4ahyij6ma2c52c17p70rdd6x1h75k9mzdf5x0";
+    sha256 = "1x6zm2qc6clc21v2s2j6q4vk3lawi86wfym0yq99lz0jv7p0vzsb";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/azure-cli-eventhubs/default.nix
+++ b/pkgs/development/python-modules/azure-cli-eventhubs/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPythonPackage, fetchPypi
+{ stdenv, buildPythonPackage, fetchPypi, python
 , azure-cli-command-modules-nspkg
 , azure-cli-core
 , azure-mgmt-eventhub
@@ -14,6 +14,12 @@ buildPythonPackage rec {
     inherit pname version format;
     sha256 = "1v2zdwf7wz7qf9m97a7xd9m0inbax7wx5awcik2j8k6j2j8sbbll";
   };
+
+  postFixup = ''
+    rm "$out/lib/${python.libPrefix}/site-packages/azure/__init__.py"
+    rm "$out/lib/${python.libPrefix}/site-packages/azure/cli/__init__.py"
+    rm "$out/lib/${python.libPrefix}/site-packages/azure/cli/command_modules/__init__.py"
+  '';
 
   propagatedBuildInputs = [
     azure-cli-command-modules-nspkg

--- a/pkgs/development/python-modules/azure-cli-eventhubs/default.nix
+++ b/pkgs/development/python-modules/azure-cli-eventhubs/default.nix
@@ -7,12 +7,12 @@
 
 buildPythonPackage rec {
   pname = "azure_cli_eventhubs";
-  version = "0.2.1";
+  version = "0.3.0";
   format = "wheel";
 
   src = fetchPypi {
     inherit pname version format;
-    sha256 = "13hxqznrpgapcv8s3jw0zn1sf9piflhql4zmh49i4bnzlj8n3n08";
+    sha256 = "1v2zdwf7wz7qf9m97a7xd9m0inbax7wx5awcik2j8k6j2j8sbbll";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/azure-cli-extension/default.nix
+++ b/pkgs/development/python-modules/azure-cli-extension/default.nix
@@ -5,14 +5,19 @@
 }:
 
 buildPythonPackage rec {
-  pname = "azure_cli_extension";
+  pname = "azure-cli-extension";
   version = "0.2.2";
-  format = "wheel";
 
   src = fetchPypi {
-    inherit pname version format;
-    sha256 = "0is6abswlrx2nri3c5kn332wv4mlqv7b19na4lzjh7p2xqf343a5";
+    inherit pname version;
+    sha256 = "1l4c0yn2yp6h4dlgny6abd8gmv27bzrrx1153y5w1g59bigbyx5w";
   };
+
+  # Hackily force build w/ wheel 0.31
+  postPatch = ''
+    sed -e '/azure-namespace-package/d' -i  setup.cfg
+    sed -e 's/wheel==0.30.0/wheel/' -i setup.py azure_cli_extension.egg-info/requires.txt
+  '';
 
   postFixup = ''
     rm "$out/lib/${python.libPrefix}/site-packages/azure/__init__.py"

--- a/pkgs/development/python-modules/azure-cli-extension/default.nix
+++ b/pkgs/development/python-modules/azure-cli-extension/default.nix
@@ -2,6 +2,7 @@
 , azure-cli-command-modules-nspkg
 , azure-cli-core
 , pip
+, wheel
 }:
 
 buildPythonPackage rec {
@@ -29,6 +30,7 @@ buildPythonPackage rec {
     azure-cli-command-modules-nspkg
     azure-cli-core
     pip
+    wheel
   ];
 
   doCheck = false;

--- a/pkgs/development/python-modules/azure-cli-extension/default.nix
+++ b/pkgs/development/python-modules/azure-cli-extension/default.nix
@@ -2,23 +2,17 @@
 , azure-cli-command-modules-nspkg
 , azure-cli-core
 , pip
-, wheel
 }:
 
 buildPythonPackage rec {
-  pname = "azure-cli-extension";
-  version = "0.2.1";
+  pname = "azure_cli_extension";
+  version = "0.2.2";
+  format = "wheel";
 
   src = fetchPypi {
-    inherit pname version;
-    sha256 = "06nygms3prjc3b5k07qkymplamva8bqalshp06f3g8a610adhwq2";
+    inherit pname version format;
+    sha256 = "0is6abswlrx2nri3c5kn332wv4mlqv7b19na4lzjh7p2xqf343a5";
   };
-
-  # Hackily force build w/ wheel 0.31
-  postPatch = ''
-    sed -e '/azure-namespace-package/d' -i  setup.cfg
-    sed -e 's/wheel==0.30.0/wheel/' -i setup.py azure_cli_extension.egg-info/requires.txt
-  '';
 
   postFixup = ''
     rm "$out/lib/${python.libPrefix}/site-packages/azure/__init__.py"
@@ -30,7 +24,6 @@ buildPythonPackage rec {
     azure-cli-command-modules-nspkg
     azure-cli-core
     pip
-    wheel
   ];
 
   doCheck = false;

--- a/pkgs/development/python-modules/azure-cli-hdinsight/default.nix
+++ b/pkgs/development/python-modules/azure-cli-hdinsight/default.nix
@@ -14,6 +14,12 @@ buildPythonPackage rec {
     sha256 = "1z57iwig06z4bbwjvynh7vrppx3spqdx72gir2r97994dw20i432";
   };
 
+  postFixup = ''
+    rm "$out/lib/${python.libPrefix}/site-packages/azure/__init__.py"
+    rm "$out/lib/${python.libPrefix}/site-packages/azure/cli/__init__.py"
+    rm "$out/lib/${python.libPrefix}/site-packages/azure/cli/command_modules/__init__.py"
+  '';
+
   propagatedBuildInputs = [
     azure-cli-command-modules-nspkg
     azure-cli-core

--- a/pkgs/development/python-modules/azure-cli-hdinsight/default.nix
+++ b/pkgs/development/python-modules/azure-cli-hdinsight/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, buildPythonPackage, fetchPypi, python
+, azure-cli-command-modules-nspkg
+, azure-cli-core
+, azure-mgmt-hdinsight
+}:
+
+buildPythonPackage rec {
+  pname = "azure_cli_hdinsight";
+  version = "0.1.0";
+  format = "wheel";
+
+  src = fetchPypi {
+    inherit pname version format;
+    sha256 = "1z57iwig06z4bbwjvynh7vrppx3spqdx72gir2r97994dw20i432";
+  };
+
+  propagatedBuildInputs = [
+    azure-cli-command-modules-nspkg
+    azure-cli-core
+    azure-mgmt-hdinsight
+  ];
+
+  doCheck = false;
+  
+  meta = with stdenv.lib; {
+    description = "Microsoft Azure Command-Line Tools HDInsight Command Module";
+    homepage = https://github.com/Azure/azure-cli;
+    license = licenses.mit;
+    maintainers = with maintainers; [ stesie ];
+  };
+}

--- a/pkgs/development/python-modules/azure-cli-interactive/default.nix
+++ b/pkgs/development/python-modules/azure-cli-interactive/default.nix
@@ -10,12 +10,12 @@
 
 buildPythonPackage rec {
   pname = "azure_cli_interactive";
-  version = "0.3.28";
+  version = "0.3.31";
   format = "wheel";
 
   src = fetchPypi {
     inherit pname version format;
-    sha256 = "0na9x8ivwdzkqf61v3h785sllhwjanl5c8v6pqvbj4cqcwpjd7lp";
+    sha256 = "1s312j4rzcgpbf0nyh4l39p4mqmi7p5l9y4g4595zdz61flw6gw4";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/azure-cli-interactive/default.nix
+++ b/pkgs/development/python-modules/azure-cli-interactive/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPythonPackage, fetchPypi
+{ stdenv, buildPythonPackage, fetchPypi, python
 , applicationinsights
 , azure-cli-command-modules-nspkg
 , azure-cli-core
@@ -17,6 +17,12 @@ buildPythonPackage rec {
     inherit pname version format;
     sha256 = "1s312j4rzcgpbf0nyh4l39p4mqmi7p5l9y4g4595zdz61flw6gw4";
   };
+
+  postFixup = ''
+    rm "$out/lib/${python.libPrefix}/site-packages/azure/__init__.py"
+    rm "$out/lib/${python.libPrefix}/site-packages/azure/cli/__init__.py"
+    rm "$out/lib/${python.libPrefix}/site-packages/azure/cli/command_modules/__init__.py"
+  '';
 
   propagatedBuildInputs = [
     applicationinsights

--- a/pkgs/development/python-modules/azure-cli-iot/default.nix
+++ b/pkgs/development/python-modules/azure-cli-iot/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPythonPackage, fetchPypi
+{ stdenv, buildPythonPackage, fetchPypi, python
 , azure-cli-command-modules-nspkg
 , azure-cli-core
 , azure-mgmt-iothub
@@ -15,6 +15,12 @@ buildPythonPackage rec {
     inherit pname version format;
     sha256 = "1wv9rfky5h8870kwad4ilz6gs4fc8c3myfxq198cnkw18ivv8cv3";
   };
+
+  postFixup = ''
+    rm "$out/lib/${python.libPrefix}/site-packages/azure/__init__.py"
+    rm "$out/lib/${python.libPrefix}/site-packages/azure/cli/__init__.py"
+    rm "$out/lib/${python.libPrefix}/site-packages/azure/cli/command_modules/__init__.py"
+  '';
 
   propagatedBuildInputs = [
     azure-cli-command-modules-nspkg

--- a/pkgs/development/python-modules/azure-cli-iot/default.nix
+++ b/pkgs/development/python-modules/azure-cli-iot/default.nix
@@ -8,12 +8,12 @@
 
 buildPythonPackage rec {
   pname = "azure_cli_iot";
-  version = "0.3.1";
+  version = "0.3.3";
   format = "wheel";
 
   src = fetchPypi {
     inherit pname version format;
-    sha256 = "0djwhiyr8nvbzc70ij9h2y0m2fhfyz79habw429ifgnwa29x244l";
+    sha256 = "1wv9rfky5h8870kwad4ilz6gs4fc8c3myfxq198cnkw18ivv8cv3";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/azure-cli-iotcentral/default.nix
+++ b/pkgs/development/python-modules/azure-cli-iotcentral/default.nix
@@ -14,6 +14,12 @@ buildPythonPackage rec {
     sha256 = "01c8wbbqcmw17i8c304xj7bkdrw5jxp5kv69ab0j2aw0jl36b96y";
   };
 
+  postFixup = ''
+    rm "$out/lib/${python.libPrefix}/site-packages/azure/__init__.py"
+    rm "$out/lib/${python.libPrefix}/site-packages/azure/cli/__init__.py"
+    rm "$out/lib/${python.libPrefix}/site-packages/azure/cli/command_modules/__init__.py"
+  '';
+
   propagatedBuildInputs = [
     azure-cli-command-modules-nspkg
     azure-cli-core

--- a/pkgs/development/python-modules/azure-cli-iotcentral/default.nix
+++ b/pkgs/development/python-modules/azure-cli-iotcentral/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, buildPythonPackage, fetchPypi, python
+, azure-cli-command-modules-nspkg
+, azure-cli-core
+, azure-mgmt-iotcentral
+}:
+
+buildPythonPackage rec {
+  pname = "azure_cli_iotcentral";
+  version = "0.1.3";
+  format = "wheel";
+
+  src = fetchPypi {
+    inherit pname version format;
+    sha256 = "01c8wbbqcmw17i8c304xj7bkdrw5jxp5kv69ab0j2aw0jl36b96y";
+  };
+
+  propagatedBuildInputs = [
+    azure-cli-command-modules-nspkg
+    azure-cli-core
+    azure-mgmt-iotcentral
+  ];
+
+  doCheck = false;
+  
+  meta = with stdenv.lib; {
+    description = "Microsoft Azure Command-Line Tools IoT Central Command Module";
+    homepage = https://github.com/Azure/azure-cli;
+    license = licenses.mit;
+    maintainers = with maintainers; [ stesie ];
+  };
+}

--- a/pkgs/development/python-modules/azure-cli-keyvault/default.nix
+++ b/pkgs/development/python-modules/azure-cli-keyvault/default.nix
@@ -9,12 +9,12 @@
 
 buildPythonPackage rec {
   pname = "azure_cli_keyvault";
-  version = "2.2.1";
+  version = "2.2.5";
   format = "wheel";
 
   src = fetchPypi {
     inherit pname version format;
-    sha256 = "028wn78ddl9dscmsd7d62gmq23j4cl9blvvlbgiw9ac0jmjld377";
+    sha256 = "0l8yi0l90sr939w84smqj4vzzgsbf091v0czsprknxp0ci1ll77r";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/azure-cli-keyvault/default.nix
+++ b/pkgs/development/python-modules/azure-cli-keyvault/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPythonPackage, fetchPypi
+{ stdenv, buildPythonPackage, fetchPypi, python
 , azure-cli-command-modules-nspkg
 , azure-cli-core
 , azure-graphrbac
@@ -16,6 +16,12 @@ buildPythonPackage rec {
     inherit pname version format;
     sha256 = "0l8yi0l90sr939w84smqj4vzzgsbf091v0czsprknxp0ci1ll77r";
   };
+
+  postFixup = ''
+    rm "$out/lib/${python.libPrefix}/site-packages/azure/__init__.py"
+    rm "$out/lib/${python.libPrefix}/site-packages/azure/cli/__init__.py"
+    rm "$out/lib/${python.libPrefix}/site-packages/azure/cli/command_modules/__init__.py"
+  '';
 
   propagatedBuildInputs = [
     azure-cli-command-modules-nspkg

--- a/pkgs/development/python-modules/azure-cli-lab/default.nix
+++ b/pkgs/development/python-modules/azure-cli-lab/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPythonPackage, fetchPypi
+{ stdenv, buildPythonPackage, fetchPypi, python
 , azure-cli-command-modules-nspkg
 , azure-cli-core
 , azure-graphrbac
@@ -14,6 +14,12 @@ buildPythonPackage rec {
     inherit pname version format;
     sha256 = "02sriz2sa2h7lvq46sq7hjq8g7yrl1z74jq90pnwggyc9v0bbs09";
   };
+
+  postFixup = ''
+    rm "$out/lib/${python.libPrefix}/site-packages/azure/__init__.py"
+    rm "$out/lib/${python.libPrefix}/site-packages/azure/cli/__init__.py"
+    rm "$out/lib/${python.libPrefix}/site-packages/azure/cli/command_modules/__init__.py"
+  '';
 
   propagatedBuildInputs = [
     azure-cli-command-modules-nspkg

--- a/pkgs/development/python-modules/azure-cli-lab/default.nix
+++ b/pkgs/development/python-modules/azure-cli-lab/default.nix
@@ -7,12 +7,12 @@
 
 buildPythonPackage rec {
   pname = "azure_cli_lab";
-  version = "0.1.1";
+  version = "0.1.2";
   format = "wheel";
 
   src = fetchPypi {
     inherit pname version format;
-    sha256 = "1c2nrwlkbwzrc40yqff7ybbv6jhpr4b540fqfynsm19ksj4d90wy";
+    sha256 = "02sriz2sa2h7lvq46sq7hjq8g7yrl1z74jq90pnwggyc9v0bbs09";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/azure-cli-maps/default.nix
+++ b/pkgs/development/python-modules/azure-cli-maps/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, buildPythonPackage, fetchPypi, python
+, azure-cli-command-modules-nspkg
+, azure-cli-core
+, azure-mgmt-maps
+}:
+
+buildPythonPackage rec {
+  pname = "azure_cli_maps";
+  version = "0.3.2";
+  format = "wheel";
+
+  src = fetchPypi {
+    inherit pname version format;
+    sha256 = "1l7arwv36j5zyy027g9wl6sv5r2hriw205w85lzjqxkdwi6dqcyj";
+  };
+
+  propagatedBuildInputs = [
+    azure-cli-command-modules-nspkg
+    azure-cli-core
+    azure-mgmt-maps
+  ];
+
+  doCheck = false;
+  
+  meta = with stdenv.lib; {
+    description = "Microsoft Azure Command-Line Tools Maps Command Module";
+    homepage = https://github.com/Azure/azure-cli;
+    license = licenses.mit;
+    maintainers = with maintainers; [ stesie ];
+  };
+}

--- a/pkgs/development/python-modules/azure-cli-monitor/default.nix
+++ b/pkgs/development/python-modules/azure-cli-monitor/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPythonPackage, fetchPypi
+{ stdenv, buildPythonPackage, fetchPypi, python
 , azure-cli-command-modules-nspkg
 , azure-cli-core
 , azure-mgmt-monitor
@@ -13,6 +13,12 @@ buildPythonPackage rec {
     inherit pname version format;
     sha256 = "0yffa8cral1fbdmnif42y70kp4h4c71i08wh4sdmk6aamz5r080z";
   };
+
+  postFixup = ''
+    rm "$out/lib/${python.libPrefix}/site-packages/azure/__init__.py"
+    rm "$out/lib/${python.libPrefix}/site-packages/azure/cli/__init__.py"
+    rm "$out/lib/${python.libPrefix}/site-packages/azure/cli/command_modules/__init__.py"
+  '';
 
   propagatedBuildInputs = [
     azure-cli-command-modules-nspkg

--- a/pkgs/development/python-modules/azure-cli-monitor/default.nix
+++ b/pkgs/development/python-modules/azure-cli-monitor/default.nix
@@ -6,12 +6,12 @@
 
 buildPythonPackage rec {
   pname = "azure_cli_monitor";
-  version = "0.2.2";
+  version = "0.2.5";
   format = "wheel";
 
   src = fetchPypi {
     inherit pname version format;
-    sha256 = "0v1xfld4p92akipc9zrqfyzj2zfaaymi25fwmy81xfi3dlli3sgp";
+    sha256 = "0yffa8cral1fbdmnif42y70kp4h4c71i08wh4sdmk6aamz5r080z";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/azure-cli-network/default.nix
+++ b/pkgs/development/python-modules/azure-cli-network/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPythonPackage, fetchPypi
+{ stdenv, buildPythonPackage, fetchPypi, python
 , azure-cli-command-modules-nspkg
 , azure-cli-core
 , azure-mgmt-dns
@@ -16,6 +16,12 @@ buildPythonPackage rec {
     inherit pname version format;
     sha256 = "0g61075pwmqnrwg1xg56lpwiac3nsy1cr03xs3zrxpk2kkq9hymv";
   };
+
+  postFixup = ''
+    rm "$out/lib/${python.libPrefix}/site-packages/azure/__init__.py"
+    rm "$out/lib/${python.libPrefix}/site-packages/azure/cli/__init__.py"
+    rm "$out/lib/${python.libPrefix}/site-packages/azure/cli/command_modules/__init__.py"
+  '';
 
   propagatedBuildInputs = [
     azure-cli-command-modules-nspkg

--- a/pkgs/development/python-modules/azure-cli-network/default.nix
+++ b/pkgs/development/python-modules/azure-cli-network/default.nix
@@ -9,12 +9,12 @@
 
 buildPythonPackage rec {
   pname = "azure_cli_network";
-  version = "2.2.4";
+  version = "2.2.7";
   format = "wheel";
 
   src = fetchPypi {
     inherit pname version format;
-    sha256 = "0z3aha978r7cwydjnp6cnahr70nsjqg0wzzxn8wfgjj23kz3j5xl";
+    sha256 = "0g61075pwmqnrwg1xg56lpwiac3nsy1cr03xs3zrxpk2kkq9hymv";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/azure-cli-nspkg/default.nix
+++ b/pkgs/development/python-modules/azure-cli-nspkg/default.nix
@@ -1,15 +1,20 @@
-{ stdenv, buildPythonPackage, fetchPypi, azure-nspkg }:
+{ stdenv, buildPythonPackage, fetchPypi
+, azure-nspkg
+}:
 
 buildPythonPackage rec {
-  pname = "azure-cli-nspkg";
+  pname = "azure_cli_nspkg";
   version = "3.0.3";
+  format = "wheel";
 
   src = fetchPypi {
-    inherit pname version;
-    sha256 = "0f92mzbknc9l26b4f5f3m943a44q4qz1xjq2klnrmixrnnax2cqp";
+    inherit pname version format;
+    sha256 = "0b1dny3sabizf4x72dcanapr6pmsbqm7lpqias1qccaal0s5q29l";
   };
 
-  propagatedBuildInputs = [ azure-nspkg ];
+  propagatedBuildInputs = [
+    azure-nspkg
+  ];
 
   doCheck = false;
 

--- a/pkgs/development/python-modules/azure-cli-policyinsights/default.nix
+++ b/pkgs/development/python-modules/azure-cli-policyinsights/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, buildPythonPackage, fetchPypi, python
+, azure-cli-command-modules-nspkg
+, azure-cli-core
+, azure-mgmt-policyinsights
+}:
+
+buildPythonPackage rec {
+  pname = "azure_cli_policyinsights";
+  version = "0.1.0";
+  format = "wheel";
+
+  src = fetchPypi {
+    inherit pname version format;
+    sha256 = "0q6ynqyr2kw4lllfwg0a29qvmcjk2b38cxkbdr7kf0j10f3vc55d";
+  };
+
+  propagatedBuildInputs = [
+    azure-cli-command-modules-nspkg
+    azure-cli-core
+    azure-mgmt-policyinsights
+  ];
+
+  doCheck = false;
+  
+  meta = with stdenv.lib; {
+    description = "Microsoft Azure Command-Line Tools Policy Insights Command Module";
+    homepage = https://github.com/Azure/azure-cli;
+    license = licenses.mit;
+    maintainers = with maintainers; [ stesie ];
+  };
+}

--- a/pkgs/development/python-modules/azure-cli-profile/default.nix
+++ b/pkgs/development/python-modules/azure-cli-profile/default.nix
@@ -5,12 +5,12 @@
 
 buildPythonPackage rec {
   pname = "azure_cli_profile";
-  version = "2.1.0";
+  version = "2.1.1";
   format = "wheel";
 
   src = fetchPypi {
     inherit pname version format;
-    sha256 = "1h1c9xsgbfq85hgbyf90lswidw32a817x7v1a67nhwfrywyycc0g";
+    sha256 = "0bb5b5az7k4ahgdq3pfrhw371i8lr5726wx6vd9ilj98s5xb3xmi";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/azure-cli-rdbms/default.nix
+++ b/pkgs/development/python-modules/azure-cli-rdbms/default.nix
@@ -7,12 +7,12 @@
 
 buildPythonPackage rec {
   pname = "azure_cli_rdbms";
-  version = "0.3.1";
+  version = "0.3.2";
   format = "wheel";
 
   src = fetchPypi {
     inherit pname version format;
-    sha256 = "0lly8jq4zrglbwbmv4aws4q82wqfmxcp2jjvzj12ls6v2gbm24pd";
+    sha256 = "18kwfjbwd9vgm6lfcicy264p6r215k08cjbjmyd49734wfjcvxzf";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/azure-cli-relay/default.nix
+++ b/pkgs/development/python-modules/azure-cli-relay/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, buildPythonPackage, fetchPypi, python
+, azure-cli-command-modules-nspkg
+, azure-cli-core
+, azure-mgmt-relay
+, six
+}:
+
+buildPythonPackage rec {
+  pname = "azure_cli_relay";
+  version = "0.1.2";
+  format = "wheel";
+
+  src = fetchPypi {
+    inherit pname version format;
+    sha256 = "05d4f51nini5qawzrv1jxkxbj7clnnw66ky0nfl2n2vksx6vxlfy";
+  };
+
+  propagatedBuildInputs = [
+    azure-cli-command-modules-nspkg
+    azure-cli-core
+    azure-mgmt-relay
+    six
+  ];
+
+  doCheck = false;
+  
+  meta = with stdenv.lib; {
+    description = "Microsoft Azure Command-Line Tools Relay Command Module";
+    homepage = https://github.com/Azure/azure-cli;
+    license = licenses.mit;
+    maintainers = with maintainers; [ stesie ];
+  };
+}

--- a/pkgs/development/python-modules/azure-cli-reservations/default.nix
+++ b/pkgs/development/python-modules/azure-cli-reservations/default.nix
@@ -6,12 +6,12 @@
 
 buildPythonPackage rec {
   pname = "azure_cli_reservations";
-  version = "0.3.2";
+  version = "0.4.0";
   format = "wheel";
 
   src = fetchPypi {
     inherit pname version format;
-    sha256 = "0mk7hvbhpsr8ykvbwzdmrfab5rl4x92r6xfzi2a78mnrjib4g4zp";
+    sha256 = "1vgm1b68vzxgf7a5vyn4gv9zrq0wkbhjj4dw5ss4wnxpwhii542x";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/azure-cli-resource/default.nix
+++ b/pkgs/development/python-modules/azure-cli-resource/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPythonPackage, fetchPypi
+{ stdenv, buildPythonPackage, fetchPypi, python
 , azure-cli-command-modules-nspkg
 , azure-cli-core
 , azure-mgmt-authorization
@@ -14,6 +14,12 @@ buildPythonPackage rec {
     inherit pname version format;
     sha256 = "0skiv4wdy1vk6j5mlbbvsrn11j8sn5s07r02csqjcqzb6q5fs0kr";
   };
+
+  postFixup = ''
+    rm "$out/lib/${python.libPrefix}/site-packages/azure/__init__.py"
+    rm "$out/lib/${python.libPrefix}/site-packages/azure/cli/__init__.py"
+    rm "$out/lib/${python.libPrefix}/site-packages/azure/cli/command_modules/__init__.py"
+  '';
 
   propagatedBuildInputs = [
     azure-cli-command-modules-nspkg

--- a/pkgs/development/python-modules/azure-cli-resource/default.nix
+++ b/pkgs/development/python-modules/azure-cli-resource/default.nix
@@ -7,12 +7,12 @@
 
 buildPythonPackage rec {
   pname = "azure_cli_resource";
-  version = "2.0.32";
+  version = "2.1.5";
   format = "wheel";
 
   src = fetchPypi {
     inherit pname version format;
-    sha256 = "0happxaw0pkysszh2s94wbklinrd7wv6xzvs210vyzx6sf2n88fa";
+    sha256 = "0skiv4wdy1vk6j5mlbbvsrn11j8sn5s07r02csqjcqzb6q5fs0kr";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/azure-cli-role/default.nix
+++ b/pkgs/development/python-modules/azure-cli-role/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPythonPackage, fetchPypi
+{ stdenv, buildPythonPackage, fetchPypi, python
 , azure-cli-command-modules-nspkg
 , azure-cli-core
 , azure-graphrbac
@@ -17,6 +17,12 @@ buildPythonPackage rec {
     inherit pname version format;
     sha256 = "1ha9zlgb3cd4d0m9x0ahl9z2qc7iipr5j4fg0p9q9hwxlxhkfb9j";
   };
+
+  postFixup = ''
+    rm "$out/lib/${python.libPrefix}/site-packages/azure/__init__.py"
+    rm "$out/lib/${python.libPrefix}/site-packages/azure/cli/__init__.py"
+    rm "$out/lib/${python.libPrefix}/site-packages/azure/cli/command_modules/__init__.py"
+  '';
 
   propagatedBuildInputs = [
     azure-cli-command-modules-nspkg

--- a/pkgs/development/python-modules/azure-cli-role/default.nix
+++ b/pkgs/development/python-modules/azure-cli-role/default.nix
@@ -10,12 +10,12 @@
 
 buildPythonPackage rec {
   pname = "azure_cli_role";
-  version = "2.1.0";
+  version = "2.1.8";
   format = "wheel";
 
   src = fetchPypi {
     inherit pname version format;
-    sha256 = "1wwcljnx9v365xypfvrgf7fb5lfisaaw9kgyy930q6wyran5ivmg";
+    sha256 = "1ha9zlgb3cd4d0m9x0ahl9z2qc7iipr5j4fg0p9q9hwxlxhkfb9j";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/azure-cli-servicebus/default.nix
+++ b/pkgs/development/python-modules/azure-cli-servicebus/default.nix
@@ -7,12 +7,12 @@
 
 buildPythonPackage rec {
   pname = "azure_cli_servicebus";
-  version = "0.2.2";
+  version = "0.3.1";
   format = "wheel";
 
   src = fetchPypi {
     inherit pname version format;
-    sha256 = "1203rgr4j10b84iwci7b5a67i2vz28qq0pg6sjlndyy7ip0zw18h";
+    sha256 = "0is604fgclxkw1d234hkga3g8z6mdbz4v7z40r8xx2b1d12556bc";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/azure-cli-servicebus/default.nix
+++ b/pkgs/development/python-modules/azure-cli-servicebus/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPythonPackage, fetchPypi
+{ stdenv, buildPythonPackage, fetchPypi, python
 , azure-cli-command-modules-nspkg
 , azure-cli-core
 , azure-mgmt-servicebus
@@ -14,6 +14,12 @@ buildPythonPackage rec {
     inherit pname version format;
     sha256 = "0is604fgclxkw1d234hkga3g8z6mdbz4v7z40r8xx2b1d12556bc";
   };
+
+  postFixup = ''
+    rm "$out/lib/${python.libPrefix}/site-packages/azure/__init__.py"
+    rm "$out/lib/${python.libPrefix}/site-packages/azure/cli/__init__.py"
+    rm "$out/lib/${python.libPrefix}/site-packages/azure/cli/command_modules/__init__.py"
+  '';
 
   propagatedBuildInputs = [
     azure-cli-command-modules-nspkg

--- a/pkgs/development/python-modules/azure-cli-servicefabric/default.nix
+++ b/pkgs/development/python-modules/azure-cli-servicefabric/default.nix
@@ -13,12 +13,12 @@
 
 buildPythonPackage rec {
   pname = "azure_cli_servicefabric";
-  version = "0.1.0";
+  version = "0.1.6";
   format = "wheel";
 
   src = fetchPypi {
     inherit pname version format;
-    sha256 = "1s3msmd9152zl6rpzivqfi1w3l92ky09mdpmaclx40fsapcw5x17";
+    sha256 = "0vw7nmg99q2nll1afc9spsw9ry64xrnqsikql3b2rcjmh919mvjv";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/azure-cli-servicefabric/default.nix
+++ b/pkgs/development/python-modules/azure-cli-servicefabric/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPythonPackage, fetchPypi
+{ stdenv, buildPythonPackage, fetchPypi, python
 , azure-cli-command-modules-nspkg
 , azure-cli-core
 , azure-graphrbac
@@ -20,6 +20,12 @@ buildPythonPackage rec {
     inherit pname version format;
     sha256 = "0vw7nmg99q2nll1afc9spsw9ry64xrnqsikql3b2rcjmh919mvjv";
   };
+
+  postFixup = ''
+    rm "$out/lib/${python.libPrefix}/site-packages/azure/__init__.py"
+    rm "$out/lib/${python.libPrefix}/site-packages/azure/cli/__init__.py"
+    rm "$out/lib/${python.libPrefix}/site-packages/azure/cli/command_modules/__init__.py"
+  '';
 
   propagatedBuildInputs = [
     azure-cli-command-modules-nspkg

--- a/pkgs/development/python-modules/azure-cli-signalr/default.nix
+++ b/pkgs/development/python-modules/azure-cli-signalr/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, buildPythonPackage, fetchPypi, python
+, azure-cli-command-modules-nspkg
+, azure-cli-core
+, azure-mgmt-signalr
+}:
+
+buildPythonPackage rec {
+  pname = "azure_cli_signalr";
+  version = "1.0.0";
+  format = "wheel";
+
+  src = fetchPypi {
+    inherit pname version format;
+    sha256 = "1qyamlfk1l4rxvmyf3s5nq9r4rswf527cl1hnhs8wn08gw85fad5";
+  };
+
+  propagatedBuildInputs = [
+    azure-cli-command-modules-nspkg
+    azure-cli-core
+    azure-mgmt-signalr
+  ];
+
+  doCheck = false;
+  
+  meta = with stdenv.lib; {
+    description = "Microsoft Azure Command-Line Tools SignalR Command Module";
+    homepage = https://github.com/Azure/azure-cli;
+    license = licenses.mit;
+    maintainers = with maintainers; [ stesie ];
+  };
+}

--- a/pkgs/development/python-modules/azure-cli-sql/default.nix
+++ b/pkgs/development/python-modules/azure-cli-sql/default.nix
@@ -8,12 +8,12 @@
 
 buildPythonPackage rec {
   pname = "azure_cli_sql";
-  version = "2.1.1";
+  version = "2.1.5";
   format = "wheel";
 
   src = fetchPypi {
     inherit pname version format;
-    sha256 = "13s9fyz19jm9lqxkd5rwnl2b4qkc6w95sac683mvk00g51b29762";
+    sha256 = "0ii07qq291jvpzbx7lh77kw1y7whzkbblvhsvi2np0bnhjbf6n8h";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/azure-cli-sql/default.nix
+++ b/pkgs/development/python-modules/azure-cli-sql/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPythonPackage, fetchPypi
+{ stdenv, buildPythonPackage, fetchPypi, python
 , azure-cli-command-modules-nspkg
 , azure-cli-core
 , azure-mgmt-sql
@@ -15,6 +15,12 @@ buildPythonPackage rec {
     inherit pname version format;
     sha256 = "0ii07qq291jvpzbx7lh77kw1y7whzkbblvhsvi2np0bnhjbf6n8h";
   };
+
+  postFixup = ''
+    rm "$out/lib/${python.libPrefix}/site-packages/azure/__init__.py"
+    rm "$out/lib/${python.libPrefix}/site-packages/azure/cli/__init__.py"
+    rm "$out/lib/${python.libPrefix}/site-packages/azure/cli/command_modules/__init__.py"
+  '';
 
   propagatedBuildInputs = [
     azure-cli-command-modules-nspkg

--- a/pkgs/development/python-modules/azure-cli-storage/default.nix
+++ b/pkgs/development/python-modules/azure-cli-storage/default.nix
@@ -7,12 +7,12 @@
 
 buildPythonPackage rec {
   pname = "azure_cli_storage";
-  version = "2.1.0";
+  version = "2.2.3";
   format = "wheel";
 
   src = fetchPypi {
     inherit pname version format;
-    sha256 = "0vx8f9k4kc2ljn31n94zywxsr86f9s5c83q9mz6qksqiy9y2ymyj";
+    sha256 = "1srww6zr7aa4llbpkhz97k9ia55bqwz08f0qr11z8gisg5qn7nqz";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/azure-cli-storage/default.nix
+++ b/pkgs/development/python-modules/azure-cli-storage/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPythonPackage, fetchPypi
+{ stdenv, buildPythonPackage, fetchPypi, python
 , azure-cli-command-modules-nspkg
 , azure-cli-core
 , azure-mgmt-storage
@@ -14,6 +14,12 @@ buildPythonPackage rec {
     inherit pname version format;
     sha256 = "1srww6zr7aa4llbpkhz97k9ia55bqwz08f0qr11z8gisg5qn7nqz";
   };
+
+  postFixup = ''
+    rm "$out/lib/${python.libPrefix}/site-packages/azure/__init__.py"
+    rm "$out/lib/${python.libPrefix}/site-packages/azure/cli/__init__.py"
+    rm "$out/lib/${python.libPrefix}/site-packages/azure/cli/command_modules/__init__.py"
+  '';
 
   propagatedBuildInputs = [
     azure-cli-command-modules-nspkg

--- a/pkgs/development/python-modules/azure-cli-telemetry/default.nix
+++ b/pkgs/development/python-modules/azure-cli-telemetry/default.nix
@@ -1,5 +1,8 @@
 { stdenv, buildPythonPackage, fetchPypi
-, applicationinsights, azure-cli-nspkg, portalocker }:
+, applicationinsights
+, azure-cli-nspkg
+, portalocker
+}:
 
 buildPythonPackage rec {
   pname = "azure_cli_telemetry";
@@ -11,7 +14,11 @@ buildPythonPackage rec {
     sha256 = "0dc5yg28szg5pw4k0ybk95al2n50zfcgsmvq15s8hwvcvgv2xw3s";
   };
 
-  propagatedBuildInputs = [ applicationinsights azure-cli-nspkg portalocker ];
+  propagatedBuildInputs = [
+    applicationinsights
+    azure-cli-nspkg
+    portalocker
+  ];
 
   doCheck = false;
 

--- a/pkgs/development/python-modules/azure-cli-vm/default.nix
+++ b/pkgs/development/python-modules/azure-cli-vm/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPythonPackage, fetchPypi
+{ stdenv, buildPythonPackage, fetchPypi, python
 , azure-cli-command-modules-nspkg
 , azure-cli-core
 , azure-keyvault
@@ -20,6 +20,12 @@ buildPythonPackage rec {
     inherit pname version format;
     sha256 = "0x3l66j93nfcxchac6p3xb0crzmss9r7qk71bmlbc50amw5dzm85";
   };
+
+  postFixup = ''
+    rm "$out/lib/${python.libPrefix}/site-packages/azure/__init__.py"
+    rm "$out/lib/${python.libPrefix}/site-packages/azure/cli/__init__.py"
+    rm "$out/lib/${python.libPrefix}/site-packages/azure/cli/command_modules/__init__.py"
+  '';
 
   propagatedBuildInputs = [
     azure-cli-command-modules-nspkg

--- a/pkgs/development/python-modules/azure-cli-vm/default.nix
+++ b/pkgs/development/python-modules/azure-cli-vm/default.nix
@@ -13,12 +13,12 @@
 
 buildPythonPackage rec {
   pname = "azure_cli_vm";
-  version = "2.1.0";
+  version = "2.2.6";
   format = "wheel";
 
   src = fetchPypi {
     inherit pname version format;
-    sha256 = "1pnqx7qyjxdv3zfjm8r7qlj6nm03by12n4xz714f5z7ir64mhjkx";
+    sha256 = "0x3l66j93nfcxchac6p3xb0crzmss9r7qk71bmlbc50amw5dzm85";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/azure-cli/default.nix
+++ b/pkgs/development/python-modules/azure-cli/default.nix
@@ -8,6 +8,7 @@
 , azure-cli-batch
 , azure-cli-batchai
 , azure-cli-billing
+, azure-cli-botservice
 , azure-cli-cdn
 , azure-cli-cloud
 , azure-cli-cognitiveservices
@@ -24,22 +25,28 @@
 , azure-cli-extension
 , azure-cli-feedback
 , azure-cli-find
+, azure-cli-hdinsight
 , azure-cli-interactive
 , azure-cli-iot
+, azure-cli-iotcentral
 , azure-cli-keyvault
 , azure-cli-lab
+, azure-cli-maps
 , azure-cli-monitor
 , azure-cli-network
 , azure-cli-nspkg
+, azure-cli-policyinsights
 , azure-cli-profile
 , azure-cli-rdbms
 , azure-cli-redis
+, azure-cli-relay
 , azure-cli-reservations
 , azure-cli-resource
 , azure-cli-role
 , azure-cli-search
 , azure-cli-servicebus
 , azure-cli-servicefabric
+, azure-cli-signalr
 , azure-cli-sql
 , azure-cli-storage
 , azure-cli-vm
@@ -47,12 +54,12 @@
 
 buildPythonPackage rec {
   pname = "azure_cli";
-  version = "2.0.45";
+  version = "2.0.49";
   format = "wheel";
 
   src = fetchPypi {
     inherit pname version format;
-    sha256 = "053mmnghgljy4v7csyah5gvf88bg6s8xzw9dsj4zcpp332v43qhn";
+    sha256 = "1q1xswz4c994h616yjcfnszrl8rhdz6my9lalzjn0d7vvihpyhdk";
   };
 
   propagatedBuildInputs = [
@@ -61,45 +68,53 @@ buildPythonPackage rec {
     azure-cli-advisor
     azure-cli-ams
     azure-cli-appservice
+    azure-cli-backup
     azure-cli-batch
     azure-cli-batchai
-    azure-cli-backup
     azure-cli-billing
+    azure-cli-botservice
     azure-cli-cdn
     azure-cli-cloud
     azure-cli-cognitiveservices
-    azure-cli-container
     azure-cli-configure
     azure-cli-consumption
+    azure-cli-container
     azure-cli-core
     azure-cli-cosmosdb
     azure-cli-dla
     azure-cli-dls
     azure-cli-dms
     azure-cli-eventgrid
+    azure-cli-eventhubs
     azure-cli-extension
     azure-cli-feedback
     azure-cli-find
+    azure-cli-hdinsight
     azure-cli-interactive
     azure-cli-iot
+    azure-cli-iotcentral
     azure-cli-keyvault
     azure-cli-lab
+    azure-cli-maps
     azure-cli-monitor
     azure-cli-network
     azure-cli-nspkg
+    azure-cli-nspkg
+    azure-cli-policyinsights
     azure-cli-profile
     azure-cli-rdbms
     azure-cli-redis
+    azure-cli-relay
     azure-cli-reservations
     azure-cli-resource
     azure-cli-role
+    azure-cli-search
+    azure-cli-servicebus
+    azure-cli-servicefabric
+    azure-cli-signalr
     azure-cli-sql
     azure-cli-storage
     azure-cli-vm
-    azure-cli-servicefabric
-    azure-cli-servicebus
-    azure-cli-eventhubs
-    azure-cli-search
   ];
 
   # filter azure-xxx-nspkg packages from $program_PYTHONPATH and wrap invoker script setting it

--- a/pkgs/development/python-modules/azure-cli/default.nix
+++ b/pkgs/development/python-modules/azure-cli/default.nix
@@ -119,11 +119,14 @@ buildPythonPackage rec {
 
   # filter azure-xxx-nspkg packages from $program_PYTHONPATH and wrap invoker script setting it
   postFixup = ''
+    rm "$out/lib/${python.libPrefix}/site-packages/azure/__init__.py"
+    rm "$out/lib/${python.libPrefix}/site-packages/azure/cli/__init__.py"
+
     IFS=: read -r -d "" -a path_array < <(printf '%s:\0' "$program_PYTHONPATH")
     filteredPythonPath=""
 
     for p in ''${path_array[@]}; do
-      if [[ ! "$p" =~ "-nspkg-" ]]; then
+      if [[ ! "$p" =~ "nspkg-" ]]; then
         filteredPythonPath="$filteredPythonPath"''${filteredPythonPath:+':'}"$p"
       fi
     done

--- a/pkgs/development/python-modules/azure-cli/default.nix
+++ b/pkgs/development/python-modules/azure-cli/default.nix
@@ -99,7 +99,6 @@ buildPythonPackage rec {
     azure-cli-monitor
     azure-cli-network
     azure-cli-nspkg
-    azure-cli-nspkg
     azure-cli-policyinsights
     azure-cli-profile
     azure-cli-rdbms

--- a/pkgs/development/python-modules/azure-common/default.nix
+++ b/pkgs/development/python-modules/azure-common/default.nix
@@ -1,19 +1,23 @@
 { stdenv, buildPythonPackage, fetchPypi, isPyPy
 , azure-nspkg
+, msrestazure
 }:
 
 buildPythonPackage rec {
-  pname = "azure-common";
-  version = "1.1.14";
+  pname = "azure_common";
+  version = "1.1.16";
+  format = "wheel";
   disabled = isPyPy;
 
   src = fetchPypi {
-    inherit pname version;
-    extension = "zip";
-    sha256 = "0ibnhid0ajnmn7nzbbkjh1jl5iyqa1bnzn1j01nl1vgxkj3wi3sg";
+    inherit pname version format;
+    sha256 = "0vjpzksb659cyg15k0sdhndg063sqb9kablnn3xfjkpbf4d64269";
   };
 
-  propagatedBuildInputs = [ azure-nspkg ];
+  propagatedBuildInputs = [
+    azure-nspkg
+    msrestazure
+  ];
 
   doCheck = false;
 

--- a/pkgs/development/python-modules/azure-datalake-store/default.nix
+++ b/pkgs/development/python-modules/azure-datalake-store/default.nix
@@ -1,5 +1,6 @@
 { stdenv, buildPythonPackage, fetchPypi, isPy27, pythonOlder
 , adal
+, azure-nspkg
 , cffi
 , futures
 , pathlib2
@@ -7,15 +8,19 @@
 
 buildPythonPackage rec {
   pname = "azure_datalake_store";
-  version = "0.0.27";
+  version = "0.0.34";
   format = "wheel";
 
   src = fetchPypi {
     inherit pname version format;
-    sha256 = "1h9073jzc2jm9lj345hx59y9rg4qp6fyislq1324hjy5vmvjpis2";
+    sha256 = "0k9l03wyql35irpa0vad2zgvp9l44y1xv621z6ym7y1fawp64axn";
   };
 
-  propagatedBuildInputs = [ adal cffi ]
+  propagatedBuildInputs = [
+    adal
+    azure-nspkg
+    cffi
+  ]
     ++ stdenv.lib.optional (isPy27) futures
     ++ stdenv.lib.optional (pythonOlder "3.4") pathlib2;
 

--- a/pkgs/development/python-modules/azure-datalake-store/default.nix
+++ b/pkgs/development/python-modules/azure-datalake-store/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPythonPackage, fetchPypi, isPy27, pythonOlder
+{ stdenv, buildPythonPackage, fetchPypi, isPy27, pythonOlder, python
 , adal
 , azure-nspkg
 , cffi
@@ -15,6 +15,10 @@ buildPythonPackage rec {
     inherit pname version format;
     sha256 = "0k9l03wyql35irpa0vad2zgvp9l44y1xv621z6ym7y1fawp64axn";
   };
+
+  postFixup = ''
+    rm "$out/lib/${python.libPrefix}/site-packages/azure/__init__.py"
+  '';
 
   propagatedBuildInputs = [
     adal

--- a/pkgs/development/python-modules/azure-graphrbac/default.nix
+++ b/pkgs/development/python-modules/azure-graphrbac/default.nix
@@ -1,28 +1,24 @@
 { stdenv, buildPythonPackage, fetchPypi
 , azure-common
 , azure-nspkg
+, msrest
 , msrestazure
 }:
 
 buildPythonPackage rec {
-  pname = "azure-graphrbac";
-  version = "0.40.0";
+  pname = "azure_graphrbac";
+  version = "0.51.1";
+  format = "wheel";
 
   src = fetchPypi {
-    inherit pname version;
-    extension = "zip";
-    sha256 = "1qlf916s4q8m1irx03imj7c4w2jmssjld34b5zz7hj3pryyrfjzr";
+    inherit pname version format;
+    sha256 = "1zx1b6cxl9x3m6j2f53qylbzfx6ka8f1ar971cjrvypa9zfz3h29";
   };
-
-  # Fix build w/ wheel 0.31, see https://github.com/Azure/azure-storage-python/pull/443
-  postPatch = ''
-    sed -i azure_bdist_wheel.py \
-      -e '1,483d' -e '/from wheel.bdist_wheel import bdist_wheel/ { s/^#//; }'
-  '';
 
   propagatedBuildInputs = [
     azure-common
     azure-nspkg
+    msrest
     msrestazure
   ];
 

--- a/pkgs/development/python-modules/azure-keyvault/default.nix
+++ b/pkgs/development/python-modules/azure-keyvault/default.nix
@@ -9,12 +9,12 @@
 
 buildPythonPackage rec {
   pname = "azure_keyvault";
-  version = "0.3.7";
+  version = "1.1.0";
   format = "wheel";
 
   src = fetchPypi {
     inherit pname version format;
-    sha256 = "1bx7i5infknjbjvq12x1xwgp6rc3nc4rwnbpg9ggvla5mjkp6wdk";
+    sha256 = "0gbi43573kkif47d790nqdslskvvy6c2wvw9wzgljs44vr637ify";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/azure-mgmt-authorization/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-authorization/default.nix
@@ -5,20 +5,14 @@
 }:
 
 buildPythonPackage rec {
-  pname = "azure-mgmt-authorization";
-  version = "0.40.0";
+  pname = "azure_mgmt_authorization";
+  version = "0.50.0";
+  format = "wheel";
 
   src = fetchPypi {
-    inherit pname version;
-    extension = "zip";
-    sha256 = "15w3rz7g3a30z3dcrgyphvsq7gn0bsy14386fv6g2087xlq8cx8x";
+    inherit pname version format;
+    sha256 = "14qhz5nm7j2yi0gqzx2rwkx1zfgd3cbknly3y9sv9cd87rv0919b";
   };
-
-  # Fix build w/ wheel 0.31, see https://github.com/Azure/azure-storage-python/pull/443
-  postPatch = ''
-    sed -i azure_bdist_wheel.py \
-      -e '1,483d' -e '/from wheel.bdist_wheel import bdist_wheel/ { s/^#//; }'
-  '';
 
   propagatedBuildInputs = [
     azure-common

--- a/pkgs/development/python-modules/azure-mgmt-batch/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-batch/default.nix
@@ -5,22 +5,20 @@
 }:
 
 buildPythonPackage rec {
-  pname = "azure-mgmt-batch";
-  version = "4.1.0";
+  pname = "azure_mgmt_batch";
+  version = "5.0.1";
+  format = "wheel";
 
   src = fetchPypi {
-    inherit pname version;
-    extension = "zip";
-    sha256 = "0nfkvh54bmjf7hn08dz3hixrkmn1yfv84spf2rrxi54avh3z8s9f";
+    inherit pname version format;
+    sha256 = "0qc10a3sac5k9sgh2fmya4kdkb6b1ap8kr23gbhal1qd30jy4hnr";
   };
 
-  # Fix build w/ wheel 0.31, see https://github.com/Azure/azure-storage-python/pull/443
-  postPatch = ''
-    sed -i azure_bdist_wheel.py \
-      -e '1,483d' -e '/from wheel.bdist_wheel import bdist_wheel/ { s/^#//; }'
-  '';
-
-  propagatedBuildInputs = [ azure-common azure-mgmt-nspkg msrestazure ];
+  propagatedBuildInputs = [
+    azure-common
+    azure-mgmt-nspkg
+    msrestazure
+  ];
 
   doCheck = false;
 

--- a/pkgs/development/python-modules/azure-mgmt-botservice/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-botservice/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, buildPythonPackage, fetchPypi, python
+, azure-common
+, azure-mgmt-nspkg
+, msrest
+, msrestazure
+}:
+
+buildPythonPackage rec {
+  pname = "azure_mgmt_botservice";
+  version = "0.1.0";
+  format = "wheel";
+
+  src = fetchPypi {
+    inherit pname version format;
+    sha256 = "0wnsw89w85qq6f2pc4x2m1mjp7995iay6ya80m2dqi17c6z7kxqx";
+  };
+
+  propagatedBuildInputs = [
+    azure-common
+    azure-mgmt-nspkg
+    msrest
+    msrestazure
+  ];
+
+  doCheck = false;
+  
+  meta = with stdenv.lib; {
+    description = "Microsoft Azure Bot Service Client Library for Python";
+    homepage = https://github.com/Azure/azure-sdk-for-python;
+    license = licenses.mit;
+    maintainers = with maintainers; [ stesie ];
+  };
+}

--- a/pkgs/development/python-modules/azure-mgmt-cognitiveservices/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-cognitiveservices/default.nix
@@ -5,20 +5,14 @@
 }:
 
 buildPythonPackage rec {
-  pname = "azure-mgmt-cognitiveservices";
-  version = "1.0.0";
+  pname = "azure_mgmt_cognitiveservices";
+  version = "3.0.0";
+  format = "wheel";
 
   src = fetchPypi {
-    inherit pname version;
-    extension = "zip";
-    sha256 = "10hmw5xrnj2hlbb4j3pb4wnmibnh2vhjjf0yxczazhi7i1f4s4ls";
+    inherit pname version format;
+    sha256 = "1zzqydlbcp63wha0q4k005mp475c4gc9qc4r98acslk69gp0dd1n";
   };
-
-  # Fix build w/ wheel 0.31, see https://github.com/Azure/azure-storage-python/pull/443
-  postPatch = ''
-    sed -i azure_bdist_wheel.py \
-      -e '1,483d' -e '/from wheel.bdist_wheel import bdist_wheel/ { s/^#//; }'
-  '';
 
   propagatedBuildInputs = [
     azure-common

--- a/pkgs/development/python-modules/azure-mgmt-compute/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-compute/default.nix
@@ -7,12 +7,12 @@
 
 buildPythonPackage rec {
   pname = "azure_mgmt_compute";
-  version = "4.0.0rc2";
+  version = "4.3.1";
   format = "wheel";
 
   src = fetchPypi {
     inherit pname version format;
-    sha256 = "1p3xs9fx1rszc4ahha8g78b2wnq2ln83pan5lzx9q9w03wwpa5gf";
+    sha256 = "0qpb05nfzkd4yd77zf94c06dzwwzdhinqdajs6cljbh2x55990l9";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/azure-mgmt-containerinstance/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-containerinstance/default.nix
@@ -1,22 +1,24 @@
 { stdenv, buildPythonPackage, fetchPypi
 , azure-common
 , azure-mgmt-nspkg
+, msrest
 , msrestazure
 }:
 
 buildPythonPackage rec {
-  pname = "azure-mgmt-containerinstance";
-  version = "1.0.0";
+  pname = "azure_mgmt_containerinstance";
+  version = "1.2.1";
+  format = "wheel";
 
   src = fetchPypi {
-    inherit pname version;
-    extension = "zip";
-    sha256 = "0by9kdag6gdhk7zqg7ab65l30l3bhlanlflknj228x9iah5ibj38";
+    inherit pname version format;
+    sha256 = "0p21gx5ifc2ywdgpn0r38y59whnwhkp22xm1r8h43g7w78yqipzx";
   };
 
   propagatedBuildInputs = [
     azure-common
     azure-mgmt-nspkg
+    msrest
     msrestazure
   ];
 

--- a/pkgs/development/python-modules/azure-mgmt-containerregistry/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-containerregistry/default.nix
@@ -7,12 +7,12 @@
 
 buildPythonPackage rec {
   pname = "azure_mgmt_containerregistry";
-  version = "2.0.0";
+  version = "2.2.0";
   format = "wheel";
 
   src = fetchPypi {
     inherit pname version format;
-    sha256 = "1ic6n9idxz8qpykkr26m6lxn8idd8wbi128261ghnh9anrn3ikrn";
+    sha256 = "11r0sckq74h5krii3bsnin3gna4wx81m5vfrln7yx169al91lifl";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/azure-mgmt-containerservice/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-containerservice/default.nix
@@ -6,20 +6,14 @@
 }:
 
 buildPythonPackage rec {
-  pname = "azure-mgmt-containerservice";
-  version = "3.0.1";
+  pname = "azure_mgmt_containerservice";
+  version = "4.2.2";
+  format = "wheel";
 
   src = fetchPypi {
-    inherit pname version;
-    extension = "zip";
-    sha256 = "0xjfrqk75nva8d1glfppvgqsd9cvfv4jhf8365nwfirsa2g75gya";
+    inherit pname version format;
+    sha256 = "1jqs497gq9xifs81kjqkpi8sg2n8g7iwpmr57plwxnqlvv15pw9g";
   };
-
-  # Fix build w/ wheel 0.31, see https://github.com/Azure/azure-storage-python/pull/443
-  postPatch = ''
-    sed -i azure_bdist_wheel.py \
-      -e '1,483d' -e '/from wheel.bdist_wheel import bdist_wheel/ { s/^#//; }'
-  '';
 
   propagatedBuildInputs = [
     azure-common

--- a/pkgs/development/python-modules/azure-mgmt-cosmosdb/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-cosmosdb/default.nix
@@ -1,22 +1,24 @@
 { stdenv, buildPythonPackage, fetchPypi
 , azure-common
 , azure-mgmt-nspkg
+, msrest
 , msrestazure
 }:
 
 buildPythonPackage rec {
-  pname = "azure-mgmt-cosmosdb";
-  version = "0.4.0";
+  pname = "azure_mgmt_cosmosdb";
+  version = "0.5.0";
+  format = "wheel";
 
   src = fetchPypi {
-    inherit pname version;
-    extension = "zip";
-    sha256 = "02jz9zw0qrixsclg694zybvzk5ycq73fclv4hkmm454bwxsar4sf";
+    inherit pname version format;
+    sha256 = "0v3z4c9rka1jimnvgjmgz60fyczm9d0lx15wid6r5c5yl1phjmbm";
   };
 
   propagatedBuildInputs = [
     azure-common
     azure-mgmt-nspkg
+    msrest
     msrestazure
   ];
 

--- a/pkgs/development/python-modules/azure-mgmt-datalake-analytics/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-datalake-analytics/default.nix
@@ -14,6 +14,12 @@ buildPythonPackage rec {
     sha256 = "0w02j14kyvgrq3qwhnz2wrqjjjzr13vpcs1yazcpwgaqwa5h1srd";
   };
 
+  propagatedBuildInputs = [
+    azure-common
+    azure-mgmt-datalake-nspkg
+    msrestazure
+  ];
+
   patches = [
     ./msrestazure-version.patch
   ];
@@ -23,12 +29,6 @@ buildPythonPackage rec {
     sed -i azure_bdist_wheel.py \
       -e '1,483d' -e '/from wheel.bdist_wheel import bdist_wheel/ { s/^#//; }'
   '';
-
-  propagatedBuildInputs = [
-    azure-common
-    azure-mgmt-datalake-nspkg
-    msrestazure
-  ];
 
   doCheck = false;
 

--- a/pkgs/development/python-modules/azure-mgmt-datalake-analytics/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-datalake-analytics/default.nix
@@ -14,6 +14,10 @@ buildPythonPackage rec {
     sha256 = "0w02j14kyvgrq3qwhnz2wrqjjjzr13vpcs1yazcpwgaqwa5h1srd";
   };
 
+  patches = [
+    ./msrestazure-version.patch
+  ];
+
   # Fix build w/ wheel 0.31, see https://github.com/Azure/azure-storage-python/pull/443
   postPatch = ''
     sed -i azure_bdist_wheel.py \

--- a/pkgs/development/python-modules/azure-mgmt-datalake-analytics/msrestazure-version.patch
+++ b/pkgs/development/python-modules/azure-mgmt-datalake-analytics/msrestazure-version.patch
@@ -1,0 +1,22 @@
+Index: azure-mgmt-datalake-analytics-0.2.0/azure_mgmt_datalake_analytics.egg-info/requires.txt
+===================================================================
+--- azure-mgmt-datalake-analytics-0.2.0.orig/azure_mgmt_datalake_analytics.egg-info/requires.txt
++++ azure-mgmt-datalake-analytics-0.2.0/azure_mgmt_datalake_analytics.egg-info/requires.txt
+@@ -1,3 +1,3 @@
+ azure-common~=1.1.5
+-msrestazure~=0.4.7
++msrestazure
+ azure-mgmt-datalake-nspkg>=2.0.0
+Index: azure-mgmt-datalake-analytics-0.2.0/setup.py
+===================================================================
+--- azure-mgmt-datalake-analytics-0.2.0.orig/setup.py
++++ azure-mgmt-datalake-analytics-0.2.0/setup.py
+@@ -66,7 +66,7 @@ setup(
+     packages=find_packages(),
+     install_requires=[
+         'azure-common~=1.1.5',
+-        'msrestazure~=0.4.7',
++        'msrestazure',
+     ],
+     cmdclass=cmdclass
+ )

--- a/pkgs/development/python-modules/azure-mgmt-datalake-nspkg/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-datalake-nspkg/default.nix
@@ -3,16 +3,19 @@
 }:
 
 buildPythonPackage rec {
-  pname = "azure-mgmt-datalake-nspkg";
-  version = "2.0.0";
+  pname = "azure_mgmt_datalake_nspkg";
+  version = "3.0.1";
+  format = "wheel";
 
   src = fetchPypi {
-    inherit pname version;
-    extension = "zip";
-    sha256 = "0dyac114yl4jycj0j9w9pgna0cfy9yccripr67212gms3957gf18";
+    inherit pname version format;
+    python = "py3";
+    sha256 = "1i123farkcrr7nmk9b24bznypvwc16ih7yy5k4hi31svql9zmiia";
   };
 
-  propagatedBuildInputs = [ azure-mgmt-nspkg ];
+  propagatedBuildInputs = [
+    azure-mgmt-nspkg
+  ];
 
   doCheck = false;
 

--- a/pkgs/development/python-modules/azure-mgmt-datalake-store/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-datalake-store/default.nix
@@ -5,20 +5,14 @@
 }:
 
 buildPythonPackage rec {
-  pname = "azure-mgmt-datalake-store";
-  version = "0.2.0";
+  pname = "azure_mgmt_datalake_store";
+  version = "0.5.0";
+  format = "wheel";
 
   src = fetchPypi {
-    inherit pname version;
-    extension = "zip";
-    sha256 = "1m0vn2mw5limh91a23n7s21mw568snb0lbqcsh94p0q0ivlwpp90";
+    inherit pname version format;
+    sha256 = "1pcmq1fix1g80jr2khg9hb79csc6ihrn3xwv4fdl7akyrlv85y9a";
   };
-
-  # Fix build w/ wheel 0.31, see https://github.com/Azure/azure-storage-python/pull/443
-  postPatch = ''
-    sed -i azure_bdist_wheel.py \
-      -e '1,483d' -e '/from wheel.bdist_wheel import bdist_wheel/ { s/^#//; }'
-  '';
 
   propagatedBuildInputs = [
     azure-common

--- a/pkgs/development/python-modules/azure-mgmt-dns/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-dns/default.nix
@@ -1,22 +1,24 @@
 { stdenv, buildPythonPackage, fetchPypi
 , azure-common
 , azure-mgmt-nspkg
+, msrest
 , msrestazure
 }:
 
 buildPythonPackage rec {
-  pname = "azure-mgmt-dns";
-  version = "2.0.0rc2";
+  pname = "azure_mgmt_dns";
+  version = "2.1.0";
+  format = "wheel";
 
   src = fetchPypi {
-    inherit pname version;
-    extension = "zip";
-    sha256 = "01fvqjsa4k12aaq5l7zcdrimlszhyg559in2ggsfp21fbxajbz6p";
+    inherit pname version format;
+    sha256 = "1vvjy5kncid2rirbimdl4i961rm7bk6jac64j2z7lb8q1xmm902v";
   };
 
   propagatedBuildInputs = [
     azure-common
     azure-mgmt-nspkg
+    msrest
     msrestazure
   ];
 

--- a/pkgs/development/python-modules/azure-mgmt-eventhub/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-eventhub/default.nix
@@ -6,20 +6,14 @@
 }:
 
 buildPythonPackage rec {
-  pname = "azure-mgmt-eventhub";
-  version = "1.2.0";
+  pname = "azure_mgmt_eventhub";
+  version = "2.1.0";
+  format = "wheel";
 
   src = fetchPypi {
-    inherit pname version;
-    extension = "zip";
-    sha256 = "05bjyyc3d8ahakb5xy3pc5b1i8nzwy569wixg8wvy7x9sz61d8rh";
+    inherit pname version format;
+    sha256 = "10d2f995y31b14gjprvds6jg075ch9sj08fdl7mwz6nshyljfizn";
   };
-
-  # Fix build w/ wheel 0.31, see https://github.com/Azure/azure-storage-python/pull/443
-  postPatch = ''
-    sed -i azure_bdist_wheel.py \
-      -e '1,483d' -e '/from wheel.bdist_wheel import bdist_wheel/ { s/^#//; }'
-  '';
 
   propagatedBuildInputs = [
     azure-common

--- a/pkgs/development/python-modules/azure-mgmt-hdinsight/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-hdinsight/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, buildPythonPackage, fetchPypi, python
+, azure-common
+, azure-mgmt-nspkg
+, msrest
+, msrestazure
+}:
+
+buildPythonPackage rec {
+  pname = "azure_mgmt_hdinsight";
+  version = "0.1.0";
+  format = "wheel";
+
+  src = fetchPypi {
+    inherit pname version format;
+    sha256 = "1b9w0djd8pv6cznfhdn2k76px75zm3slzjk1l0qjr9g8a7v84sfm";
+  };
+
+  propagatedBuildInputs = [
+    azure-common
+    azure-mgmt-nspkg
+    msrest
+    msrestazure
+  ];
+
+  doCheck = false;
+  
+  meta = with stdenv.lib; {
+    description = "Microsoft Azure HDInsight Management Client Library for Python";
+    homepage = https://github.com/Azure/azure-sdk-for-python;
+    license = licenses.mit;
+    maintainers = with maintainers; [ stesie ];
+  };
+}

--- a/pkgs/development/python-modules/azure-mgmt-iotcentral/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-iotcentral/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, buildPythonPackage, fetchPypi, python
+, azure-common
+, azure-mgmt-nspkg
+, msrest
+, msrestazure
+}:
+
+buildPythonPackage rec {
+  pname = "azure_mgmt_iotcentral";
+  version = "0.2.0";
+  format = "wheel";
+
+  src = fetchPypi {
+    inherit pname version format;
+    sha256 = "0mzvinc5hyppnkry7dp54w0fpxrvfi192i18ygs20hspc64caw83";
+  };
+
+  propagatedBuildInputs = [
+    azure-common
+    azure-mgmt-nspkg
+    msrest
+    msrestazure
+  ];
+
+  doCheck = false;
+  
+  meta = with stdenv.lib; {
+    description = "Microsoft Azure IoTCentral Management Client Library for Python";
+    homepage = https://github.com/Azure/azure-sdk-for-python;
+    license = licenses.mit;
+    maintainers = with maintainers; [ stesie ];
+  };
+}

--- a/pkgs/development/python-modules/azure-mgmt-iothub/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-iothub/default.nix
@@ -1,20 +1,26 @@
 { stdenv, buildPythonPackage, fetchPypi
 , azure-common
 , azure-mgmt-nspkg
+, msrest
 , msrestazure
 }:
 
 buildPythonPackage rec {
-  pname = "azure-mgmt-iothub";
-  version = "0.5.0";
+  pname = "azure_mgmt_iothub";
+  version = "0.6.0";
+  format = "wheel";
 
   src = fetchPypi {
-    inherit pname version;
-    extension = "zip";
-    sha256 = "1ghl5ln9w2zn2m61gjmd497wkzw0rzg409vxx6hg0i38xm182f08";
+    inherit pname version format;
+    sha256 = "0favdj6n58sm89v2ayhbcn9wk5fdf6gdin3f03qdy47fpq6nnnlw";
   };
 
-  propagatedBuildInputs = [ azure-common azure-mgmt-nspkg msrestazure ];
+  propagatedBuildInputs = [
+    azure-common
+    azure-mgmt-nspkg
+    msrest
+    msrestazure
+  ];
 
   doCheck = false;
 

--- a/pkgs/development/python-modules/azure-mgmt-keyvault/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-keyvault/default.nix
@@ -6,20 +6,14 @@
 }:
 
 buildPythonPackage rec {
-  pname = "azure-mgmt-keyvault";
-  version = "0.40.0";
+  pname = "azure_mgmt_keyvault";
+  version = "1.1.0";
+  format = "wheel";
 
   src = fetchPypi {
-    inherit pname version;
-    extension = "zip";
-    sha256 = "0c7x4357jrxm4w1pqp9008x039jpy8r11d5bhgxzfmwivjyaqzzv";
+    inherit pname version format;
+    sha256 = "00gcr1pnkxczfskyq5xrf7jaw9cwr0pxy61jmqxrxgva4fv9hqj0";
   };
-
-  # Fix build w/ wheel 0.31, see https://github.com/Azure/azure-storage-python/pull/443
-  postPatch = ''
-    sed -i azure_bdist_wheel.py \
-      -e '1,483d' -e '/from wheel.bdist_wheel import bdist_wheel/ { s/^#//; }'
-  '';
 
   propagatedBuildInputs = [
     azure-common

--- a/pkgs/development/python-modules/azure-mgmt-maps/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-maps/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, buildPythonPackage, fetchPypi, python
+, azure-common
+, azure-mgmt-nspkg
+, msrestazure
+}:
+
+buildPythonPackage rec {
+  pname = "azure_mgmt_maps";
+  version = "0.1.0";
+  format = "wheel";
+
+  src = fetchPypi {
+    inherit pname version format;
+    sha256 = "103sh2k0skgn5lm429m2m84sfhkcs9nmh6ziacz3k5fdpgfv2yd7";
+  };
+
+  propagatedBuildInputs = [
+    azure-common
+    azure-mgmt-nspkg
+    msrestazure
+  ];
+
+  doCheck = false;
+  
+  meta = with stdenv.lib; {
+    description = "Microsoft Azure Maps Client Library for Python";
+    homepage = https://github.com/Azure/azure-sdk-for-python;
+    license = licenses.mit;
+    maintainers = with maintainers; [ stesie ];
+  };
+}

--- a/pkgs/development/python-modules/azure-mgmt-monitor/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-monitor/default.nix
@@ -5,20 +5,14 @@
 }:
 
 buildPythonPackage rec {
-  pname = "azure-mgmt-monitor";
-  version = "0.5.0";
+  pname = "azure_mgmt_monitor";
+  version = "0.5.2";
+  format = "wheel";
 
   src = fetchPypi {
-    inherit pname version;
-    extension = "zip";
-    sha256 = "0rgz8p5fkknfdz7gn09hlm7k8i2a8k7yypvl43mk51p0iy88rrl1";
+    inherit pname version format;
+    sha256 = "0pl9al483qgxd2l9p3xqg9drxzi01zzn05qlqvlkfj39a2hng243";
   };
-
-  # Fix build w/ wheel 0.31, see https://github.com/Azure/azure-storage-python/pull/443
-  postPatch = ''
-    sed -i azure_bdist_wheel.py \
-      -e '1,483d' -e '/from wheel.bdist_wheel import bdist_wheel/ { s/^#//; }'
-  '';
 
   propagatedBuildInputs = [
     azure-common

--- a/pkgs/development/python-modules/azure-mgmt-msi/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-msi/default.nix
@@ -5,20 +5,14 @@
 }:
 
 buildPythonPackage rec {
-  pname = "azure-mgmt-msi";
-  version = "0.1.0";
+  pname = "azure_mgmt_msi";
+  version = "0.2.0";
+  format = "wheel";
 
   src = fetchPypi {
-    inherit pname version;
-    extension = "zip";
-    sha256 = "0n486bx7ag79ycbc51b1c1dxla130gnhwck8sns69dskhjydgvjk";
+    inherit pname version format;
+    sha256 = "09m0hkqagp8pmn7h7yxch0h0i24s3k1vf9l5d07clkmzacbyd2g9";
   };
-
-  # Fix build w/ wheel 0.31, see https://github.com/Azure/azure-storage-python/pull/443
-  postPatch = ''
-    sed -i azure_bdist_wheel.py \
-      -e '1,483d' -e '/from wheel.bdist_wheel import bdist_wheel/ { s/^#//; }'
-  '';
 
   propagatedBuildInputs = [
     azure-common

--- a/pkgs/development/python-modules/azure-mgmt-network/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-network/default.nix
@@ -1,22 +1,24 @@
 { stdenv, buildPythonPackage, fetchPypi
 , azure-common
 , azure-mgmt-nspkg
+, msrest
 , msrestazure
 }:
 
 buildPythonPackage rec {
-  pname = "azure-mgmt-network";
-  version = "2.0.0rc3";
+  pname = "azure_mgmt_network";
+  version = "2.2.1";
+  format = "wheel";
 
   src = fetchPypi {
-    inherit pname version;
-    extension = "zip";
-    sha256 = "1vg7ly27mm6kzgb7r4fncggilhchhlfpa30vg91jhbhajx3xirc7";
+    inherit pname version format;
+    sha256 = "1q99cvpshwxy487yh3xfa3iqis4xc574wa0nzlm76hbf2rn9g8h5";
   };
 
   propagatedBuildInputs = [
     azure-common
     azure-mgmt-nspkg
+    msrest
     msrestazure
   ];
 

--- a/pkgs/development/python-modules/azure-mgmt-nspkg/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-nspkg/default.nix
@@ -3,16 +3,19 @@
 }:
 
 buildPythonPackage rec {
-  pname = "azure-mgmt-nspkg";
-  version = "2.0.0";
+  pname = "azure_mgmt_nspkg";
+  version = "3.0.2";
+  format = "wheel";
 
   src = fetchPypi {
-    inherit pname version;
-    extension = "zip";
-    sha256 = "0vrycmdgqz7z0qfhakmzr5hgsj0l11pyirn3bkpnimnpypa8hr73";
+    inherit pname version format;
+    python = "py3";
+    sha256 = "16b9s672yjlxsbw8n1wjy27ms3r0man2ksrzjkdj7lryv9gylf6n";
   };
 
-  propagatedBuildInputs = [ azure-nspkg ];
+  propagatedBuildInputs = [
+    azure-nspkg
+  ];
 
   meta = with stdenv.lib; {
     description = "Microsoft Azure Resource Management Namespace Package [Internal]";

--- a/pkgs/development/python-modules/azure-mgmt-policyinsights/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-policyinsights/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, buildPythonPackage, fetchPypi, python
+, azure-common
+, azure-mgmt-nspkg
+, msrestazure
+}:
+
+buildPythonPackage rec {
+  pname = "azure_mgmt_policyinsights";
+  version = "0.1.0";
+  format = "wheel";
+
+  src = fetchPypi {
+    inherit pname version format;
+    sha256 = "0jds22rfbg03ljc8i774qxc5ghr8i1r2njgzh80h6fl2pwqq7f29";
+  };
+
+  propagatedBuildInputs = [
+    azure-common
+    azure-mgmt-nspkg
+    msrestazure
+  ];
+
+  doCheck = false;
+  
+  meta = with stdenv.lib; {
+    description = "Microsoft Azure Policy Insights Client Library for Python";
+    homepage = https://github.com/Azure/azure-sdk-for-python;
+    license = licenses.mit;
+    maintainers = with maintainers; [ stesie ];
+  };
+}

--- a/pkgs/development/python-modules/azure-mgmt-rdbms/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-rdbms/default.nix
@@ -1,22 +1,24 @@
 { stdenv, buildPythonPackage, fetchPypi
 , azure-common
 , azure-mgmt-nspkg
+, msrest
 , msrestazure
 }:
 
 buildPythonPackage rec {
-  pname = "azure-mgmt-rdbms";
-  version = "1.2.0";
+  pname = "azure_mgmt_rdbms";
+  version = "1.3.0";
+  format = "wheel";
 
   src = fetchPypi {
-    inherit pname version;
-    extension = "zip";
-    sha256 = "0qq22jrx34iz0dxinxscidgfaiy84vm4750il7flj4dczkrbwnkf";
+    inherit pname version format;
+    sha256 = "14sp30921fd5a0b8w9nnhad3h0i67lk830sc8s2acb0nmqbjvn7k";
   };
 
   propagatedBuildInputs = [
     azure-common
     azure-mgmt-nspkg
+    msrest
     msrestazure
   ];
 

--- a/pkgs/development/python-modules/azure-mgmt-recoveryservices/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-recoveryservices/default.nix
@@ -5,13 +5,13 @@
 }:
 
 buildPythonPackage rec {
-  pname = "azure_mgmt_recoveryservices";
+  pname = "azure-mgmt-recoveryservices";
   version = "0.1.0";
-  format = "wheel";
 
   src = fetchPypi {
-    inherit pname version format;
-    sha256 = "1ll7wq4m65jacdgjs75v7lky57wn9cp3zi4yv3d98xap40gkxf6a";
+    inherit pname version;
+    extension = "zip";
+    sha256 = "1vssmv6hyzz2ih5csjz7gyyk738vfb33wdlwf969yig2py7mp1xz";
   };
 
   propagatedBuildInputs = [
@@ -19,6 +19,16 @@ buildPythonPackage rec {
     azure-mgmt-nspkg
     msrestazure
   ];
+
+  patches = [
+    ./msrestazure-version.patch
+  ];
+
+  # Fix build w/ wheel 0.31, see https://github.com/Azure/azure-storage-python/pull/443
+  postPatch = ''
+    sed -i azure_bdist_wheel.py \
+      -e '1,483d' -e '/from wheel.bdist_wheel import bdist_wheel/ { s/^#//; }'
+  '';
 
   doCheck = false;
 

--- a/pkgs/development/python-modules/azure-mgmt-recoveryservices/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-recoveryservices/default.nix
@@ -5,22 +5,20 @@
 }:
 
 buildPythonPackage rec {
-  pname = "azure-mgmt-recoveryservices";
+  pname = "azure_mgmt_recoveryservices";
   version = "0.1.0";
+  format = "wheel";
 
   src = fetchPypi {
-    inherit pname version;
-    extension = "zip";
-    sha256 = "1vssmv6hyzz2ih5csjz7gyyk738vfb33wdlwf969yig2py7mp1xz";
+    inherit pname version format;
+    sha256 = "1ll7wq4m65jacdgjs75v7lky57wn9cp3zi4yv3d98xap40gkxf6a";
   };
 
-  # Fix build w/ wheel 0.31, see https://github.com/Azure/azure-storage-python/pull/443
-  postPatch = ''
-    sed -i azure_bdist_wheel.py \
-      -e '1,483d' -e '/from wheel.bdist_wheel import bdist_wheel/ { s/^#//; }'
-  '';
-
-  propagatedBuildInputs = [ azure-common azure-mgmt-nspkg msrestazure ];
+  propagatedBuildInputs = [
+    azure-common
+    azure-mgmt-nspkg
+    msrestazure
+  ];
 
   doCheck = false;
 

--- a/pkgs/development/python-modules/azure-mgmt-recoveryservices/msrestazure-version.patch
+++ b/pkgs/development/python-modules/azure-mgmt-recoveryservices/msrestazure-version.patch
@@ -1,0 +1,22 @@
+Index: azure-mgmt-recoveryservices-0.1.0/azure_mgmt_recoveryservices.egg-info/requires.txt
+===================================================================
+--- azure-mgmt-recoveryservices-0.1.0.orig/azure_mgmt_recoveryservices.egg-info/requires.txt
++++ azure-mgmt-recoveryservices-0.1.0/azure_mgmt_recoveryservices.egg-info/requires.txt
+@@ -1,3 +1,3 @@
+-msrestazure~=0.4.11
++msrestazure
+ azure-common~=1.1
+ azure-mgmt-nspkg>=2.0.0
+Index: azure-mgmt-recoveryservices-0.1.0/setup.py
+===================================================================
+--- azure-mgmt-recoveryservices-0.1.0.orig/setup.py
++++ azure-mgmt-recoveryservices-0.1.0/setup.py
+@@ -78,7 +78,7 @@ setup(
+     zip_safe=False,
+     packages=find_packages(),
+     install_requires=[
+-        'msrestazure~=0.4.11',
++        'msrestazure',
+         'azure-common~=1.1',
+     ],
+     cmdclass=cmdclass

--- a/pkgs/development/python-modules/azure-mgmt-recoveryservicesbackup/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-recoveryservicesbackup/default.nix
@@ -14,6 +14,12 @@ buildPythonPackage rec {
     sha256 = "0rhwbjxffhg52md5kkvqz1258vq37xl0fw3pvxml0xvqbi7m36m0";
   };
 
+  propagatedBuildInputs = [
+    azure-common
+    azure-mgmt-nspkg
+    msrestazure
+  ];
+
   patches = [
     ./msrestazure-version.patch
   ];
@@ -23,12 +29,6 @@ buildPythonPackage rec {
     sed -i azure_bdist_wheel.py \
       -e '1,483d' -e '/from wheel.bdist_wheel import bdist_wheel/ { s/^#//; }'
   '';
-
-  propagatedBuildInputs = [
-    azure-common
-    azure-mgmt-nspkg
-    msrestazure
-  ];
 
   doCheck = false;
 

--- a/pkgs/development/python-modules/azure-mgmt-recoveryservicesbackup/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-recoveryservicesbackup/default.nix
@@ -14,6 +14,10 @@ buildPythonPackage rec {
     sha256 = "0rhwbjxffhg52md5kkvqz1258vq37xl0fw3pvxml0xvqbi7m36m0";
   };
 
+  patches = [
+    ./msrestazure-version.patch
+  ];
+
   # Fix build w/ wheel 0.31, see https://github.com/Azure/azure-storage-python/pull/443
   postPatch = ''
     sed -i azure_bdist_wheel.py \

--- a/pkgs/development/python-modules/azure-mgmt-recoveryservicesbackup/msrestazure-version.patch
+++ b/pkgs/development/python-modules/azure-mgmt-recoveryservicesbackup/msrestazure-version.patch
@@ -1,0 +1,22 @@
+Index: azure-mgmt-recoveryservicesbackup-0.1.1/azure_mgmt_recoveryservicesbackup.egg-info/requires.txt
+===================================================================
+--- azure-mgmt-recoveryservicesbackup-0.1.1.orig/azure_mgmt_recoveryservicesbackup.egg-info/requires.txt
++++ azure-mgmt-recoveryservicesbackup-0.1.1/azure_mgmt_recoveryservicesbackup.egg-info/requires.txt
+@@ -1,3 +1,3 @@
+-msrestazure~=0.4.11
++msrestazure
+ azure-common~=1.1
+ azure-mgmt-nspkg>=2.0.0
+Index: azure-mgmt-recoveryservicesbackup-0.1.1/setup.py
+===================================================================
+--- azure-mgmt-recoveryservicesbackup-0.1.1.orig/setup.py
++++ azure-mgmt-recoveryservicesbackup-0.1.1/setup.py
+@@ -78,7 +78,7 @@ setup(
+     zip_safe=False,
+     packages=find_packages(),
+     install_requires=[
+-        'msrestazure~=0.4.11',
++        'msrestazure',
+         'azure-common~=1.1',
+     ],
+     cmdclass=cmdclass

--- a/pkgs/development/python-modules/azure-mgmt-relay/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-relay/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, buildPythonPackage, fetchPypi, python
+, azure-common
+, azure-mgmt-nspkg
+, msrestazure
+}:
+
+buildPythonPackage rec {
+  pname = "azure_mgmt_relay";
+  version = "0.1.0";
+  format = "wheel";
+
+  src = fetchPypi {
+    inherit pname version format;
+    sha256 = "0z58xc4jgpvakfcv9l4lgbsb7mmpmz0bypx7qxm1driwawsff48l";
+  };
+
+  propagatedBuildInputs = [
+    azure-common
+    azure-mgmt-nspkg
+    msrestazure
+  ];
+
+  doCheck = false;
+  
+  meta = with stdenv.lib; {
+    description = "Microsoft Azure Relay Client Library for Python";
+    homepage = https://github.com/Azure/azure-sdk-for-python;
+    license = licenses.mit;
+    maintainers = with maintainers; [ stesie ];
+  };
+}

--- a/pkgs/development/python-modules/azure-mgmt-reservations/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-reservations/default.nix
@@ -1,22 +1,24 @@
 { stdenv, buildPythonPackage, fetchPypi
 , azure-common
 , azure-mgmt-nspkg
+, msrest
 , msrestazure
 }:
 
 buildPythonPackage rec {
-  pname = "azure-mgmt-reservations";
-  version = "0.2.1";
+  pname = "azure_mgmt_reservations";
+  version = "0.3.0";
+  format = "wheel";
 
   src = fetchPypi {
-    inherit pname version;
-    extension = "zip";
-    sha256 = "0wf1da3f4w3yalkylxv5ifq1bpsyk26j77v4ha0phyn400vqlqa0";
+    inherit pname version format;
+    sha256 = "0i1x9ibnvcikhscdff6mm5a724phqbsqrmd68ay4fwwqvip74clp";
   };
 
   propagatedBuildInputs = [
     azure-common
     azure-mgmt-nspkg
+    msrest
     msrestazure
   ];
 

--- a/pkgs/development/python-modules/azure-mgmt-resource/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-resource/default.nix
@@ -5,16 +5,20 @@
 }:
 
 buildPythonPackage rec {
-  pname = "azure-mgmt-resource";
-  version = "2.0.0rc2";
+  pname = "azure_mgmt_resource";
+  version = "2.0.0";
+  format = "wheel";
 
   src = fetchPypi {
-    inherit pname version;
-    extension = "zip";
-    sha256 = "1anh3m73ppfs12x9cngzgpkp4xqsms52iy2vyaazag9jns9j8709";
+    inherit pname version format;
+    sha256 = "136dav3zj43w59ams02qj6dcjfmbyq781r3yjaq4zw422i965kcd";
   };
 
-  propagatedBuildInputs = [ azure-common azure-mgmt-nspkg msrestazure ];
+  propagatedBuildInputs = [
+    azure-common
+    azure-mgmt-nspkg
+    msrestazure
+  ];
 
   doCheck = false;
 

--- a/pkgs/development/python-modules/azure-mgmt-servicebus/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-servicebus/default.nix
@@ -1,22 +1,24 @@
 { stdenv, buildPythonPackage, fetchPypi
 , azure-common
 , azure-mgmt-nspkg
+, msrest
 , msrestazure
 }:
 
 buildPythonPackage rec {
-  pname = "azure-mgmt-servicebus";
-  version = "0.5.1";
+  pname = "azure_mgmt_servicebus";
+  version = "0.5.2";
+  format = "wheel";
 
   src = fetchPypi {
-    inherit pname version;
-    extension = "zip";
-    sha256 = "13cq9gn7knsbxma9m8fwmv5jal8rgdlprqxm00779iq6h88yjxvr";
+    inherit pname version format;
+    sha256 = "12yflarvahk53la51jl482mli302scw8srsjzc87j99c57nycb98";
   };
 
   propagatedBuildInputs = [
     azure-common
     azure-mgmt-nspkg
+    msrest
     msrestazure
   ];
 

--- a/pkgs/development/python-modules/azure-mgmt-servicefabric/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-servicefabric/default.nix
@@ -6,20 +6,14 @@
 }:
 
 buildPythonPackage rec {
-  pname = "azure-mgmt-servicefabric";
-  version = "0.1.0";
+  pname = "azure_mgmt_servicefabric";
+  version = "0.2.0";
+  format = "wheel";
 
   src = fetchPypi {
-    inherit pname version;
-    extension = "zip";
-    sha256 = "0wv3rni1jyqrh75nf5gzag2437fmy5j3wnnc10bgiz11qayqjxwz";
+    inherit pname version format;
+    sha256 = "1s53svsfrwvsxzizmsj5dxjk6ias7258jnw52g33dh6hi7kk850c";
   };
-
-  # Fix build w/ wheel 0.31, see https://github.com/Azure/azure-storage-python/pull/443
-  postPatch = ''
-    sed -i azure_bdist_wheel.py \
-      -e '1,483d' -e '/from wheel.bdist_wheel import bdist_wheel/ { s/^#//; }'
-  '';
 
   propagatedBuildInputs = [
     azure-common

--- a/pkgs/development/python-modules/azure-mgmt-signalr/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-signalr/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, buildPythonPackage, fetchPypi, python
+, azure-common
+, azure-mgmt-nspkg
+, msrest
+, msrestazure
+}:
+
+buildPythonPackage rec {
+  pname = "azure_mgmt_signalr";
+  version = "0.1.1";
+  format = "wheel";
+
+  src = fetchPypi {
+    inherit pname version format;
+    sha256 = "0m86csb8xlkl65pvmlk0vpgspjl70ck8l96zkjyxsjmg47z9v9rp";
+  };
+
+  propagatedBuildInputs = [
+    azure-common
+    azure-mgmt-nspkg
+    msrest
+    msrestazure
+  ];
+
+  doCheck = false;
+  
+  meta = with stdenv.lib; {
+    description = "Microsoft Azure SignalR Client Library for Python";
+    homepage = https://github.com/Azure/azure-sdk-for-python;
+    license = licenses.mit;
+    maintainers = with maintainers; [ stesie ];
+  };
+}

--- a/pkgs/development/python-modules/azure-mgmt-storage/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-storage/default.nix
@@ -5,20 +5,14 @@
 }:
 
 buildPythonPackage rec {
-  pname = "azure-mgmt-storage";
-  version = "1.5.0";
+  pname = "azure_mgmt_storage";
+  version = "2.0.0rc4";
+  format = "wheel";
 
   src = fetchPypi {
-    inherit pname version;
-    extension = "zip";
-    sha256 = "189526acwqclnq2mrjlldi9xd0amja7n2bg1zxfy7pji60lkmz5i";
+    inherit pname version format;
+    sha256 = "1lq6g078hyl68bjdyd0gac66w8c4j79kq4bk3c4d3gpk5x06y45m";
   };
-
-  # Fix build w/ wheel 0.31, see https://github.com/Azure/azure-storage-python/pull/443
-  postPatch = ''
-    sed -i azure_bdist_wheel.py \
-      -e '1,483d' -e '/from wheel.bdist_wheel import bdist_wheel/ { s/^#//; }'
-  '';
 
   propagatedBuildInputs = [
     azure-common

--- a/pkgs/development/python-modules/azure-mgmt-web/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-web/default.nix
@@ -1,28 +1,24 @@
 { stdenv, buildPythonPackage, fetchPypi
 , azure-common
 , azure-mgmt-nspkg
+, msrest
 , msrestazure
 }:
 
 buildPythonPackage rec {
-  pname = "azure-mgmt-web";
-  version = "0.35.0";
+  pname = "azure_mgmt_web";
+  version = "0.40.0";
+  format = "wheel";
 
   src = fetchPypi {
-    inherit pname version;
-    extension = "zip";
-    sha256 = "02nchnbkqh1mh6libba2qcv9vdsshna9n9hk7ivmg8i2xx77k84f";
+    inherit pname version format;
+    sha256 = "0j285ia5vhgyh9rmh5vsn1yjv7k2lbcmzbji2kykls0j6yrjc6bf";
   };
-
-  # Fix build w/ wheel 0.31, see https://github.com/Azure/azure-storage-python/pull/443
-  postPatch = ''
-    sed -i azure_bdist_wheel.py \
-      -e '1,483d' -e '/from wheel.bdist_wheel import bdist_wheel/ { s/^#//; }'
-  '';
 
   propagatedBuildInputs = [
     azure-common
     azure-mgmt-nspkg
+    msrest
     msrestazure
   ];
 

--- a/pkgs/development/python-modules/azure-multiapi-storage/default.nix
+++ b/pkgs/development/python-modules/azure-multiapi-storage/default.nix
@@ -2,19 +2,19 @@
 , azure-common
 , azure-nspkg
 , cryptography
+, futures
 , python-dateutil
 , requests
-, futures
 }:
 
 buildPythonPackage rec {
   pname = "azure_multiapi_storage";
-  version = "0.2.1";
+  version = "0.2.2";
   format = "wheel";
 
   src = fetchPypi {
     inherit pname version format;
-    sha256 = "091qz206v9k6vb2lvr7shlhjsln711gplg8rf5f3wx6z35i2i5h4";
+    sha256 = "01cbdhsarsy3n0vg725xccj09a4fz1lbggchnka3lpj6mikkk9d3";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/azure-nspkg/default.nix
+++ b/pkgs/development/python-modules/azure-nspkg/default.nix
@@ -1,14 +1,19 @@
-{ stdenv, buildPythonPackage, fetchPypi }:
+{ stdenv, buildPythonPackage, fetchPypi
+}:
 
 buildPythonPackage rec {
-  pname = "azure-nspkg";
-  version = "2.0.0";
+  pname = "azure_nspkg";
+  version = "3.0.2";
+  format = "wheel";
 
   src = fetchPypi {
-    inherit pname version;
-    extension = "zip";
-    sha256 = "0yyw3wcy7xkrxwg7150a1wivgzwwyl877z2p4pv8xvk6iifyw6gy";
+    inherit pname version format;
+    python = "py3";
+    sha256 = "0a2y8cvddngld0icksq4whkwjs37ll0zxiwz6syixv80rb56181i";
   };
+
+  propagatedBuildInputs = [
+  ];
 
   doCheck = false;
 

--- a/pkgs/development/python-modules/azure-storage-blob/default.nix
+++ b/pkgs/development/python-modules/azure-storage-blob/default.nix
@@ -6,19 +6,14 @@
 }:
 
 buildPythonPackage rec {
-  pname = "azure-storage-blob";
-  version = "1.1.0";
+  pname = "azure_storage_blob";
+  version = "1.3.1";
+  format = "wheel";
 
   src = fetchPypi {
-    inherit pname version;
-    sha256 = "0rhwi4jwk261c7ljb1pzb4y9i2rbzhk1pznzifjrf3vdwchdrp2g";
+    inherit pname version format;
+    sha256 = "1p1ch0sw6ipvxix2dbxrn8jlkc5703mhfr0zv4q5i7vqznmmi01h";
   };
-
-  # Fix build w/ wheel 0.31, see https://github.com/Azure/azure-storage-python/pull/443
-  postPatch = ''
-    sed -i azure_bdist_wheel.py \
-      -e '1,483d' -e '/from wheel.bdist_wheel import bdist_wheel/ { s/^#//; }'
-  '';
 
   propagatedBuildInputs = [
     azure-common

--- a/pkgs/development/python-modules/azure-storage-common/default.nix
+++ b/pkgs/development/python-modules/azure-storage-common/default.nix
@@ -7,19 +7,14 @@
 }:
 
 buildPythonPackage rec {
-  pname = "azure-storage-common";
-  version = "1.1.0";
+  pname = "azure_storage_common";
+  version = "1.3.0";
+  format = "wheel";
 
   src = fetchPypi {
-    inherit pname version;
-    sha256 = "1ks0h2vvswgknhxpwp9njy3q25r1mp3hl1fald6nrwcymnqa8rwc";
+    inherit pname version format;
+    sha256 = "0sqrr7raavnfhvdbxqbyxhp2qv7wsprg2mnf628gjaz8323af4m4";
   };
-
-  # Fix build w/ wheel 0.31, see https://github.com/Azure/azure-storage-python/pull/443
-  postPatch = ''
-    sed -i azure_bdist_wheel.py \
-      -e '1,483d' -e '/from wheel.bdist_wheel import bdist_wheel/ { s/^#//; }'
-  '';
 
   propagatedBuildInputs = [
     azure-common

--- a/pkgs/development/python-modules/humanfriendly/default.nix
+++ b/pkgs/development/python-modules/humanfriendly/default.nix
@@ -5,13 +5,16 @@
 buildPythonPackage rec {
   pname = "humanfriendly";
   version = "4.16.1";
+  format = "wheel";
 
   src = fetchPypi {
-    inherit pname version;
-    sha256 = "0ywzfpg7b1k6s6m9yps4yfs6l7pjp4rcrp8vnhapynbb0np9h7pd";
+    inherit pname version format;
+    sha256 = "0qs3ck0zn98cnmafnwrby7r8qbj5d3jdrwkb4l3339s1pjp6l6a9";
   };
 
-  propagatedBuildInputs = [ monotonic ];
+  propagatedBuildInputs = [
+    monotonic
+  ];
 
   doCheck = false;
 

--- a/pkgs/development/python-modules/knack/default.nix
+++ b/pkgs/development/python-modules/knack/default.nix
@@ -10,16 +10,23 @@
 
 buildPythonPackage rec {
   pname = "knack";
-  version = "0.4.1";
+  version = "0.4.4";
+  format = "wheel";
 
   src = fetchPypi {
-    inherit pname version;
-    sha256 = "182rp3y6y8b0lbsrpi9k5qvg9q7p1qffqp79sv9izygsq9lzsids";
+    inherit pname version format;
+    sha256 = "18r88z4zr50xdjjivvn7vpdqzgyh9rr0z1x25lmwsfpv0sgzw75j";
   };
 
-  # TODO (stesie): dependency enum34 for python < 3.4
-  propagatedBuildInputs = [ argcomplete colorama jmespath pygments pyyaml
-                            six tabulate ];
+  propagatedBuildInputs = [
+    argcomplete
+    colorama
+    jmespath
+    pygments
+    pyyaml
+    six
+    tabulate
+  ];
 
   doCheck = false;
 

--- a/pkgs/development/python-modules/msrest/default.nix
+++ b/pkgs/development/python-modules/msrest/default.nix
@@ -1,23 +1,33 @@
 { stdenv, buildPythonPackage, fetchPypi
+, aiodns
+, aiohttp
+, certifi
+, isodate
 , requests
 , requests_oauthlib
-, isodate
-, certifi
 }:
 
 buildPythonPackage rec {
   pname = "msrest";
-  version = "0.4.29";
+  version = "0.6.1";
+  format = "wheel";
 
   src = fetchPypi {
-    inherit pname version;
-    sha256 = "0ifbcihdwd5rpd92r9by6s4imj422crj8vn6gpwbzixpff0ma2nf";
+    inherit pname version format;
+    sha256 = "06gfy360plqbzhxni2d7xvn0cv9k15bjvfq3ismk04l2wh095xqm";
   };
 
   # TODO (stesie): dependencies for python < 3.5
   # Requires-Dist: enum34 (>=1.0.4); python_version<'3.4'
   # Requires-Dist: typing; python_version<'3.5'
-  propagatedBuildInputs = [ requests requests_oauthlib isodate certifi ];
+  propagatedBuildInputs = [
+    aiodns
+    aiohttp
+    certifi
+    isodate
+    requests
+    requests_oauthlib
+  ];
 
   doCheck = false;
 

--- a/pkgs/development/python-modules/msrestazure/default.nix
+++ b/pkgs/development/python-modules/msrestazure/default.nix
@@ -1,19 +1,22 @@
 { stdenv, buildPythonPackage, fetchPypi
 , adal
-, keyring
 , msrest
 }:
 
 buildPythonPackage rec {
   pname = "msrestazure";
-  version = "0.4.34";
+  version = "0.5.0";
+  format = "wheel";
 
   src = fetchPypi {
-    inherit pname version;
-    sha256 = "1r3dkqd0isfgc21994xb5qk80skspv2rr4jdj2mr9c6mxh1lmjag";
+    inherit pname version format;
+    sha256 = "0q1nvwv3wi2ghpp9h4b0civfwy6w6n1h3cxh65dz18si0cyivwvk";
   };
 
-  propagatedBuildInputs = [ adal keyring msrest ];
+  propagatedBuildInputs = [
+    adal
+    msrest
+  ];
 
   doCheck = false;
 


### PR DESCRIPTION
This patchset updates azure-cli to more recent versions (as of today's latest docker container), as proposed by @colemickens in #2 

Interestingly the module set in the docker container isn't fully valid according to module version requirements.  There are some modules dependant on "msrestazure~=0.4.x", yet 0.5.0 is installed ...

... anyways, I've added patches so installation works correctly with 0.5.0

The auto-update script currently doesn't add new packages to the root default.nix and assumes all packages to be format=wheel (which isn't true in every case currently). But at least it's a start :)
